### PR TITLE
fix(get_entities): bugs lab is not shown after researching steal-processing

### DIFF
--- a/env/src/lib/serialize.lua
+++ b/env/src/lib/serialize.lua
@@ -1248,11 +1248,11 @@ global.utils.serialize_entity = function(entity)
 
     -- Add the current research to the lab
     if entity.name == "lab" then
-        if game.players[1].force.current_research ~= nil then
-            serialized.research = game.players[1].force.current_research.name
-        else
-            serialized.research = nil
-        end
+        -- if game.players[1].force.current_research ~= nil then
+        --     serialized.research = game.players[1].force.current_research.name
+        -- else
+        --     serialized.research = nil
+        -- end
     end
 
     -- Add input and output locations if the entity is a offshore pump

--- a/env/src/lib/serialize.lua
+++ b/env/src/lib/serialize.lua
@@ -1248,6 +1248,7 @@ global.utils.serialize_entity = function(entity)
 
     -- Add the current research to the lab
     if entity.name == "lab" then
+        -- fix(#150): to fix bugs that lab is not shown after researching some technologies
         -- if game.players[1].force.current_research ~= nil then
         --     serialized.research = game.players[1].force.current_research.name
         -- else


### PR DESCRIPTION
There seems to be a bug that lab is not shown after researching steal-processing or logstic science pack 🤔 (In Open-Play)

before researching steal-processing
```
[
	...
	Chest(name='wooden-chest', direction=Direction.UP, position=Position(x=7.5, y=95.5), energy=0.0, status=EntityStatus.NORMAL, inventory=Inventory({}), height=1.0, width=1.0), 
	Furnace(fuel=Inventory({'coal': 45}), name='stone-furnace', direction=Direction.UP, position=Position(x=19.0, y=95.0), energy=1600.0, status=EntityStatus.WORKING, furnace_source=Inventory({'iron-ore': 48}), furnace_result=Inventory({'copper-plate': 17}), height=2.0, width=2.0), 
	Lab(position=Position(x=82.5 y=96.5), lab_input={}, status=EntityStatus.NO_RESEARCH_IN_PROGRESS, electrical_id=1728, warnings=[]), 
	Furnace(fuel=Inventory({'coal': 1}), name='stone-furnace', direction=Direction.UP, position=Position(x=6.0, y=97.0), energy=1600.0, status=EntityStatus.WORKING, furnace_source=Inventory({'copper-ore': 49}), 
	...
]
```

after
![image](https://github.com/user-attachments/assets/d7311642-2c7a-4b89-aeb5-424a7468e11d)

```
[
	...
	Chest(name='wooden-chest', direction=Direction.UP, position=Position(x=7.5, y=95.5), energy=0.0, status=EntityStatus.NORMAL, inventory=Inventory({}), height=1.0, width=1.0), 
	Furnace(fuel=Inventory({'coal': 45}), name='stone-furnace', direction=Direction.UP, position=Position(x=19.0, y=95.0), energy=1600.0, status=EntityStatus.FULL_OUTPUT, furnace_source=Inventory({'iron-ore': 48}), furnace_result=Inventory({'copper-plate': 17}), height=2.0, width=2.0), 
        // lab disappeared!!
	Furnace(fuel=Inventory({'coal': 1}), name='stone-furnace', direction=Direction.UP, position=Position(x=6.0, y=97.0), energy=1600.0, warnings=['furnace source is full', 'furnace result is full'], status=EntityStatus.FULL_OUTPUT, furnace_source=Inventory({'copper-ore': 50}), furnace_result=Inventory({'copper-plate': 100}), height=2.0, width=2.0), 
	...
]
```

I noticed this happens after researching steal-processing, logistic science pack, or solar energy. Though I'm not sure about the precise trigger, it seems to happen in technologies around logistic science pack.

And finally it turned out that it is caused by lines in serialize.lua around lab serialization, and it is resolved by commenting them out.
I'm sorry but I'm not familiar with factorio API and Lua code, so it was hard to find the root cause...

For now, this code is used to add `research` attribute to lab entity and it would be OK to comment it out, because research progress can be obtained by get_research_progress tool and it's something shared among all labs.