### PR TITLE
Feature/add exiting on task success

### DIFF
--- a/eval/open/independent_runs/run.py
+++ b/eval/open/independent_runs/run.py
@@ -45,6 +45,7 @@ def main():
             agent=agent,
             version=version,
             version_description=f"model:{run_config['model']}\ntype:{task.task_key}",
+            exit_on_task_success=run_config.get("exit_on_task_success", True),
         )
 
         p = multiprocessing.Process(

--- a/eval/open/independent_runs/run_config.json
+++ b/eval/open/independent_runs/run_config.json
@@ -3,7 +3,8 @@
 "model": "gpt-4o-mini-2024-07-18",
 "version": 768},
 {"task": "plastic_bar_throughput_16.json",
-"model": "gpt-4o-mini-2024-07-18"},
+"model": "gpt-4o-mini-2024-07-18",
+"exit_on_task_success": false},
 {"task": "open_play.json",
 "model": "gpt-4o-mini-2024-07-18"}
 ]

--- a/eval/open/independent_runs/trajectory_runner.py
+++ b/eval/open/independent_runs/trajectory_runner.py
@@ -35,6 +35,7 @@ class EvalConfig:
     agent: AgentABC
     version: int
     version_description: str
+    exit_on_task_success: bool
 
 
 class TrajectoryRunner:

--- a/eval/open/independent_runs/trajectory_runner.py
+++ b/eval/open/independent_runs/trajectory_runner.py
@@ -166,12 +166,6 @@ class TrajectoryRunner:
                 print(f"Evaluated program {multiprocessing.current_process().name} - "
                       f"Model: {self.config.agent.model} - "
                       f"Iteration {iteration}/{self.config.agent.task.trajectory_length}")
-                if task_verification_response.success and self.config.exit_on_task_success:
-                    print(f"Task verification success: {task_verification_response.success}")
-                    completion_result = CompletionResult(step = iteration, 
-                                                         reason = CompletionReason.SUCCESS)
-                    await self.config.agent.end(program.conversation, completion_result)
-                    break
                 if not evaluated_program:
                     continue
 
@@ -222,7 +216,7 @@ class TrajectoryRunner:
                           f"Elapsed: {elapsed_str} - "
                           f"ETA: {eta}")
                     
-                if task_verification_response.success:
+                if task_verification_response.success and self.config.exit_on_task_success:
                     print(f"Task verification success: {task_verification_response.success}")
                     completion_result = CompletionResult(step = iteration, 
                                                          reason = CompletionReason.SUCCESS)

--- a/eval/open/independent_runs/trajectory_runner.py
+++ b/eval/open/independent_runs/trajectory_runner.py
@@ -166,7 +166,12 @@ class TrajectoryRunner:
                 print(f"Evaluated program {multiprocessing.current_process().name} - "
                       f"Model: {self.config.agent.model} - "
                       f"Iteration {iteration}/{self.config.agent.task.trajectory_length}")
-
+                if task_verification_response.success and self.config.exit_on_task_success:
+                    print(f"Task verification success: {task_verification_response.success}")
+                    completion_result = CompletionResult(step = iteration, 
+                                                         reason = CompletionReason.SUCCESS)
+                    await self.config.agent.end(program.conversation, completion_result)
+                    break
                 if not evaluated_program:
                     continue
 


### PR DESCRIPTION
Added the feature to stop task runs when the task verification is success

By default, all tasks will stop once successfully completed
To not stop at task completion, the "exit_on_task_success" flag needs to be set to "false" at run_config json