### PR TITLE
Fix/remove duplicate installation docs new

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -54,8 +54,7 @@ If you prefer using Hatch, you can still do so:
 For development, you can install the package in editable mode:
 
 ```bash
-python prepare_build.py
-pip install -e .
+python prepare_build.py && pip install -e
 ```
 
 This creates the necessary package structure and installs the package in development mode, allowing changes to be reflected immediately without reinstalling.

--- a/README.md
+++ b/README.md
@@ -56,12 +56,6 @@ You can install the factorio-learning-environment package directly using pip:
 ```bash
 # Install from PyPI
 pip install factorio-learning-environment
-
-# Install with optional components
-pip install factorio-learning-environment[agents]  # For agent support
-pip install factorio-learning-environment[eval]    # For evaluation tools
-pip install factorio-learning-environment[cluster] # For cluster deployment
-pip install factorio-learning-environment[all]     # All optional dependencies
 ```
 
 ### Development Installation
@@ -74,11 +68,7 @@ git clone https://github.com/yourusername/factorio-learning-environment.git
 cd factorio-learning-environment
 
 # Install in development mode
-python setuptools_build.py develop
-# OR
-python prepare_build.py && pip install -e .
-# OR Install with development dependencies
-pip install -e ".[dev]"
+python prepare_build.py && pip install -e
 ```
 
 See [BUILD.md](BUILD.md) for detailed build instructions.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pip install factorio-learning-environment[all]     # All optional dependencies
 
 ### Development Installation
 
-For development, install the package in editable mode. Each method has specific use cases:
+For development, install the package in editable mode:
 
 ```bash
 # Clone the repository

--- a/README.md
+++ b/README.md
@@ -66,42 +66,27 @@ pip install factorio-learning-environment[all]     # All optional dependencies
 
 ### Development Installation
 
-For development, install the package in editable mode:
+For development, install the package in editable mode. Each method has specific use cases:
 
 ```bash
 # Clone the repository
 git clone https://github.com/yourusername/factorio-learning-environment.git
 cd factorio-learning-environment
 
-# Install in development mode
+# Install in development mode (choose one method)
 python setuptools_build.py develop
-# OR
+
+# Method 2: Two-step build process
+# - First prepares the build environment and dependencies
+# - Then performs the editable installation
+# - Recommended for first-time setup
 python prepare_build.py && pip install -e .
-```
-
-See [BUILD.md](BUILD.md) for detailed build instructions.
-
-### Install using pip
-
-The Factorio Learning Environment package can be installed directly using pip:
-
-```bash
-pip install factorio-learning-environment
-```
-
-### Development Installation
-
-For development, you can install the package in editable mode:
-
-```bash
-# Clone the repository
-git clone https://github.com/JackHopkins/factorio-learning-environment.git
-cd factorio-learning-environment
-
-# Install in development mode
+# OR
 pip install -e .
 
 # Install with development dependencies
+# - Adds testing, linting, and other development tools
+# - Required for running tests and contributing
 pip install -e ".[dev]"
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,20 +73,11 @@ For development, install the package in editable mode. Each method has specific 
 git clone https://github.com/yourusername/factorio-learning-environment.git
 cd factorio-learning-environment
 
-# Install in development mode (choose one method)
+# Install in development mode
 python setuptools_build.py develop
-
-# Method 2: Two-step build process
-# - First prepares the build environment and dependencies
-# - Then performs the editable installation
-# - Recommended for first-time setup
-python prepare_build.py && pip install -e .
 # OR
-pip install -e .
-
-# Install with development dependencies
-# - Adds testing, linting, and other development tools
-# - Required for running tests and contributing
+python prepare_build.py && pip install -e .
+# OR Install with development dependencies
 pip install -e ".[dev]"
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ pip install -e .
 pip install -e ".[dev]"
 ```
 
+See [BUILD.md](BUILD.md) for detailed build instructions.
+
 ### Usage
 
 After installation, you can import the package in your Python code:


### PR DESCRIPTION
## Description
Removes duplicate installation instructions from README.md to improve documentation clarity.

## Related Issues
I was wondering whether the duplicate information in the README and the build.md is intentional.

For example, these below scripts are Repeated in both, which seems unnecessary to me:

pip install factorio-learning-environment[agents]  # For agent support
pip install factorio-learning-environment[eval]    # For evaluation tools
pip install factorio-learning-environment[cluster] # For cluster deployment
pip install factorio-learning-environment[all]     # All optional dependencies