### PR TITLE
removing multiagent task strings from default tasks

### DIFF
--- a/eval/tasks/task_definitions/iron_ore_throughput_16.json
+++ b/eval/tasks/task_definitions/iron_ore_throughput_16.json
@@ -2,7 +2,7 @@
 {                          
    "task_type": "throughput",
     "config": {
-        "goal_description":"Create an automatic iron ore factory that produces 16 iron ore per 60 ingame seconds. IMPORTANT: Start and end every program with a message to the other agents using send_message() tool.",
+        "goal_description":"Create an automatic iron ore factory that produces 16 iron ore per 60 ingame seconds.",
         "throughput_entity":"iron-ore",
         "quota":16,
         "trajectory_length": 128,

--- a/eval/tasks/task_definitions/iron_plate_throughput_16.json
+++ b/eval/tasks/task_definitions/iron_plate_throughput_16.json
@@ -1,7 +1,7 @@
 {
     "task_type": "throughput",
     "config": {
-        "goal_description":"Create an automatic iron plate factory that produces 16 iron plate per 60 ingame seconds. IMPORTANT: Start and end every program with a message to the other agents using send_message() tool. End each program with a send_message() call to confirm your actions. If your program errored out this message will not be sent. If you are Agent 1, focus on electric power production (boilers, engines, coal extraction, etc). If you are Agent 2, focus on the iron plate factory (iron ore extraction, furnaces, etc).",
+        "goal_description":"Create an automatic iron plate factory that produces 16 iron plate per 60 ingame seconds.",
         "throughput_entity":"iron-plate",
         "quota":16,
         "trajectory_length": 128,


### PR DESCRIPTION
Removed multi-agent string additons from default task descriptions as they were probably put there by mistake