### PR TITLE
fixed connect to server check for player exists

### DIFF
--- a/env/src/instance.py
+++ b/env/src/instance.py
@@ -256,8 +256,8 @@ class FactorioInstance:
 
         try:
             rcon_client.connect()
-            player_exists = rcon_client.send_command('/sc rcon.print(game.players[1].position)')
-            if not player_exists:
+            player_count = rcon_client.send_command('/sc rcon.print(#game.players)')
+            if int(player_count) <= 0:
                 raise Exception(
                     "Player hasn't been initialised into the game. Please log in once to make this node operational.")
             #rcon_client.send_command('/sc global = {}')


### PR DESCRIPTION
fixed rcon client command output parsing issue for the player exists check in instance.py.

old behaviour: expects that it will raise an error if a player position is none, however it always returns true.

new behaviour: if there is a single player it continues otherwise it raises an error.

fixes #217 