### PR TITLE
Sqlite db default

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -14,8 +14,8 @@ OPEN_ROUTER_API_KEY=XXX
 FLE_DB_TYPE="sqlite"
 
 # SQLite Configuration (used when FLE_DB_TYPE=sqlite or as fallback)
-# If not set, defaults to ~/.fle/data.db
-SQLITE_DB_FILE="~/.fle/data.db"
+# If not set, defaults to .fle/data.db
+SQLITE_DB_FILE=".fle/data.db"
 
 # PostgreSQL Configuration (only needed when FLE_DB_TYPE=postgres)
 SKILLS_DB_HOST=XXX

--- a/.example.env
+++ b/.example.env
@@ -9,10 +9,15 @@ TOGETHER_API_KEY=XXX
 DEEPSEEK_API_KEY=XXX
 OPEN_ROUTER_API_KEY=XXX
 
-# SQLite configuration (recommended for beginners)
-SQLITE_DB_FILE=XXX
+# Database Configuration
+# Options: "sqlite" (default) or "postgres"
+FLE_DB_TYPE="sqlite"
 
-# If using a Postgres DB
+# SQLite Configuration (used when FLE_DB_TYPE=sqlite or as fallback)
+# If not set, defaults to ~/.fle/data.db
+SQLITE_DB_FILE="~/.fle/data.db"
+
+# PostgreSQL Configuration (only needed when FLE_DB_TYPE=postgres)
 SKILLS_DB_HOST=XXX
 SKILLS_DB_PORT=XXX
 SKILLS_DB_NAME=XXX

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ cortex
 /.idea/
 .DS_Store
 .env
+.fle/
 ~/PycharmProjects/PaperclipMaximiser/dev/
 /client/log/
 /client/unscored_log/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /venv/
+.venv/
 cortex
 /dev/
 .idea

--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ factorio-learning-environment/
 ```
 
 ## Database
-To run long trajectories in FLE, we support checkpointing at every agent step using a SQL database. The `db_client` implements the interface for saving and loading agent outputs, environment feedbacks, game states and histories of the current trajectory. We support out of the box SQLite (default) and Postgres databases. The easiest way how to set up a FLE-compatible databse is to use SQLite and setup the programs table:
+To run long trajectories in FLE, we support checkpointing at every agent step using a SQL database. The `db_client` implements the interface for saving and loading agent outputs, environment feedbacks, game states and histories of the current trajectory. We support out of the box SQLite (default) and Postgres databases. The easiest way how to set up a FLE-compatible databse is to use the default SQLite.
 
 We recommend setting up the FLE_DB_TYPE variable in the .env file. It defaults to `.fle/data.db` in your working directory.
 
@@ -732,8 +732,6 @@ SKILLS_DB_NAME=fle_database
 SKILLS_DB_USER=fle_user
 SKILLS_DB_PASSWORD=fle123
 ```
-
-
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ ANTHROPIC_API_KEY=<KEY>
 TOGETHER_API_KEY=<KEY>
 OPEN_ROUTER_API_KEY=<KEY>
 
+# two db options are available "sqlite" (default) and "postgres"
+FLE_DB_TYPE="sqlite"
+
 # If using Postgres DB, NOT REQUIRED (See section on Database)
 SKILLS_DB_PORT=""
 SKILLS_DB_NAME=""
@@ -162,7 +165,7 @@ SKILLS_DB_USER=""
 SKILLS_DB_PASSWORD=""
 
 # If using SQLite for DB (See section on Database)
-SQLITE_DB_FILE = ""
+SQLITE_DB_FILE = ".fle/data.db"
 
 # AWS credentials if wanting to use Cloudformation, NOT REQUIRED
 AWS_SECRET_ACCESS_KEY=<KEY>
@@ -176,7 +179,7 @@ If you are not using a Postgres DB, you should create an SQLite database file:
 sqlite3 mydatabase.db
 ```
 
-Create the required tables:
+The programs table is created automatically for either db:
 ```
 CREATE TABLE programs (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -204,8 +207,6 @@ CREATE TABLE programs (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 ```
-
-And replace the `PostgresDBClient` object at `create_db_client` function in `eval\open\independent_runs\trajectory_runner.py` with the SQLliteDBClient object (see [Database](#database) section).
 
 9. **Run Eval**: Running open and lab play with example run configs:
    1. Open Play (one parallel run): `python eval/open/independent_runs/run.py --run_config=eval/open/independent_runs/run_config_example_open_play.json`
@@ -710,55 +711,29 @@ factorio-learning-environment/
 ```
 
 ## Database
-To run long trajectories in FLE, we support checkpointing at every agent step using a SQL database. The `db_client` implements the interface for saving and loading agent outputs, environment feedbacks, game states and histories of the current trajectory. We support out of the box Postgres and SQLite databases. The easiest way how to set up a FLE-compatible databse is to use SQLite and setup the programs table:
+To run long trajectories in FLE, we support checkpointing at every agent step using a SQL database. The `db_client` implements the interface for saving and loading agent outputs, environment feedbacks, game states and histories of the current trajectory. We support out of the box SQLite (default) and Postgres databases. The easiest way how to set up a FLE-compatible databse is to use SQLite and setup the programs table:
+
+We recommend setting up the FLE_DB_TYPE variable in the .env file. It defaults to `.fle/data.db` in your working directory.
+
+To utilize postgres database you need to setup an instance of the db server yourself. The easiest way is to use it via Docker:
+
+`docker run --name fle-postgres -e POSTGRES_PASSWORD=fle123 -e POSTGRES_USER=fle_user -e POSTGRES_DB=fle_database -p 5432:5432 -d postgres:15`
+
+You then need to make sure all the correct variables are put in the `.env` file. With the `FLE_DB_TYPE="postgres"`
 
 ```
-# create the db file
-sqlite3 mydatabase.db
+# Database Configuration - Set to postgres to use PostgreSQL
+FLE_DB_TYPE="postgres"
 
-# create the programs table
-CREATE TABLE programs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    code TEXT NOT NULL,
-    value REAL DEFAULT 0.0,
-    visits INTEGER DEFAULT 0,
-    parent_id INTEGER,
-    state_json TEXT,
-    conversation_json TEXT NOT NULL,
-    completion_token_usage INTEGER,
-    prompt_token_usage INTEGER,
-    token_usage INTEGER,
-    response TEXT,
-    holdout_value REAL,
-    raw_reward REAL,
-    version INTEGER DEFAULT 1,
-    version_description TEXT DEFAULT '',
-    model TEXT DEFAULT 'gpt-4o',
-    meta TEXT,
-    achievements_json TEXT,
-    instance INTEGER DEFAULT -1,
-    depth REAL DEFAULT 0.0,
-    advantage REAL DEFAULT 0.0,
-    ticks INTEGER DEFAULT 0,
-    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-);
+# PostgreSQL Configuration
+SKILLS_DB_HOST=localhost
+SKILLS_DB_PORT=5432
+SKILLS_DB_NAME=fle_database
+SKILLS_DB_USER=fle_user
+SKILLS_DB_PASSWORD=fle123
 ```
 
-The SQLite database can then be instantiated to be used for tasks in the `create_db_client` function at `eval\open\independent_runs\trajectory_runner.py`. 
-We recommend setting up the database_file variable in the .env file
 
-```
-from eval.open.db_client import SQLliteDBClient
-async def create_db_client() -> SQLliteDBClient:
-    """Create database client with connection pool"""
-    return SQLliteDBClient(
-        max_conversation_length=40,
-        min_connections=2,
-        max_connections=5,
-        # Provide the SQLite database file path
-        database_file=os.getenv("SQLITE_DB_FILE") #"mydatabase.db"
-    )
-```
 
 ## Benchmarks
 

--- a/env/src/instance.py
+++ b/env/src/instance.py
@@ -256,8 +256,8 @@ class FactorioInstance:
 
         try:
             rcon_client.connect()
-            player_exists = rcon_client.send_command('/sc rcon.print(game.players[1].position)')
-            if not player_exists:
+            player_count = rcon_client.send_command('/sc rcon.print(#game.players)')
+            if int(player_count) <= 0:
                 raise Exception(
                     "Player hasn't been initialised into the game. Please log in once to make this node operational.")
             #rcon_client.send_command('/sc global = {}')

--- a/eval/open/db_client.py
+++ b/eval/open/db_client.py
@@ -16,6 +16,8 @@ from env.src.models.program import Program
 from env.src.models.conversation import Conversation
 from env.src.models.game_state import GameState
 import sqlite3
+import os
+from pathlib import Path
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -515,7 +517,7 @@ class SQLliteDBClient(DBClient):
             print(f"Error fetching largest version: {e}")
 
 
-    async def get_resume_state(self, resume_version, process_id) -> tuple[Optional[GameState], Optional[Conversation], Optional[int], Optional[int]]:
+    async def get_resume_state(self, resume_version, process_id, agent_idx=-1) -> tuple[Optional[GameState], Optional[Conversation], Optional[int], Optional[int]]:
         """Get the state to resume from"""
         try:
             # Get most recent successful program to resume from
@@ -525,13 +527,14 @@ class SQLliteDBClient(DBClient):
             AND state_json IS NOT NULL
             AND value IS NOT NULL
             AND json_extract(meta, '$.process_id') = ?
+            AND instance = ?
             ORDER BY created_at DESC
             LIMIT 1
             """
 
             with self.get_connection() as conn:
                 cur = conn.cursor()
-                cur.execute(query, (resume_version, process_id))
+                cur.execute(query, (resume_version, process_id, agent_idx))
                 results = cur.fetchall()
 
             if not results:
@@ -606,3 +609,102 @@ class SQLliteDBClient(DBClient):
             conn.rollback()
             print(f"Error creating program: {e}")
             raise e
+
+def create_default_sqlite_db(db_file: str) -> None:
+    """Create SQLite database with required schema if it doesn't exist"""
+    db_path = Path(db_file)
+    
+    # Create directory if it doesn't exist
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    
+    # Create database and table if they don't exist
+    conn = sqlite3.connect(db_file)
+    try:
+        cursor = conn.cursor()
+        
+        # Check if programs table exists
+        cursor.execute("""
+            SELECT name FROM sqlite_master 
+            WHERE type='table' AND name='programs'
+        """)
+        
+        if not cursor.fetchone():
+            print(f"Creating SQLite database schema in {db_file}")
+            cursor.execute("""
+                CREATE TABLE programs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    code TEXT NOT NULL,
+                    value REAL DEFAULT 0.0,
+                    visits INTEGER DEFAULT 0,
+                    parent_id INTEGER,
+                    state_json TEXT,
+                    conversation_json TEXT NOT NULL,
+                    completion_token_usage INTEGER,
+                    prompt_token_usage INTEGER,
+                    token_usage INTEGER,
+                    response TEXT,
+                    holdout_value REAL,
+                    raw_reward REAL,
+                    version INTEGER DEFAULT 1,
+                    version_description TEXT DEFAULT '',
+                    model TEXT DEFAULT 'gpt-4o',
+                    meta TEXT,
+                    achievements_json TEXT,
+                    instance INTEGER DEFAULT -1,
+                    depth REAL DEFAULT 0.0,
+                    advantage REAL DEFAULT 0.0,
+                    ticks INTEGER DEFAULT 0,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            conn.commit()
+            print("SQLite database schema created successfully!")
+        
+    finally:
+        conn.close()
+
+
+async def create_db_client(max_conversation_length: int = 40, 
+                          min_connections: int = 2, 
+                          max_connections: int = 5) -> DBClient:
+    """
+    Create database client based on environment configuration.
+    Defaults to SQLite with automatic setup.
+    """
+    # Check for database type preference
+    db_type = os.getenv("FLE_DB_TYPE", "sqlite").lower()
+    
+    if db_type == "postgres" or db_type == "postgresql":
+        # Use PostgreSQL if explicitly requested and configured
+        required_vars = ["SKILLS_DB_HOST", "SKILLS_DB_PORT", "SKILLS_DB_NAME", "SKILLS_DB_USER", "SKILLS_DB_PASSWORD"]
+        missing_vars = [var for var in required_vars if not os.getenv(var)]
+        
+        if missing_vars:
+            print(f"Warning: PostgreSQL requested but missing environment variables: {missing_vars}")
+            print("Falling back to SQLite...")
+            db_type = "sqlite"
+            raise Exception(f"Missing environment variables: {missing_vars}")
+        else:
+            return PostgresDBClient(
+                max_conversation_length=max_conversation_length,
+                min_connections=min_connections,
+                max_connections=max_connections,
+                host=os.getenv("SKILLS_DB_HOST"),
+                port=os.getenv("SKILLS_DB_PORT"),
+                dbname=os.getenv("SKILLS_DB_NAME"),
+                user=os.getenv("SKILLS_DB_USER"),
+                password=os.getenv("SKILLS_DB_PASSWORD")
+            )
+    
+    # Default to SQLite
+    sqlite_file = os.getenv("SQLITE_DB_FILE") or os.path.expanduser("~/.factorio-learning-environment/data.db")
+    
+    # Auto-create SQLite database if it doesn't exist
+    create_default_sqlite_db(sqlite_file)
+    
+    return SQLliteDBClient(
+        max_conversation_length=max_conversation_length,
+        min_connections=min_connections,
+        max_connections=max_connections,
+        database_file=sqlite_file
+    )

--- a/eval/open/independent_runs/trajectory_runner.py
+++ b/eval/open/independent_runs/trajectory_runner.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 from agents import CompletionResult, CompletionReason
 from agents.agent_abc import AgentABC
 from agents.basic_agent import BasicAgent
-from eval.open.db_client import PostgresDBClient, SQLliteDBClient
+from eval.open.db_client import DBClient, create_db_client
 from eval.open.independent_runs.simple_evaluator import SimpleFactorioEvaluator
 from env.src.models.conversation import Conversation
 from env.src.models.message import Message
@@ -55,7 +55,7 @@ class TrajectoryRunner:
     def __init__(self,
                  #llm_factory: LLMFactory,
                  agents: list[AgentABC],
-                 db_client: PostgresDBClient,
+                 db_client: DBClient,
                  evaluator: SimpleFactorioEvaluator,
                  config: EvalConfig,
                  process_id: int):
@@ -359,20 +359,6 @@ async def create_factorio_instance(instance_id: int, num_agents: int = 1, agent_
 
     instance.speed(10)
     return instance
-
-
-async def create_db_client() -> PostgresDBClient:
-    """Create database client with connection pool"""
-    return PostgresDBClient(
-        max_conversation_length=40,
-        min_connections=2,
-        max_connections=5,
-        host=os.getenv("SKILLS_DB_HOST"),
-        port=os.getenv("SKILLS_DB_PORT"),
-        dbname=os.getenv("SKILLS_DB_NAME"),
-        user=os.getenv("SKILLS_DB_USER"),
-        password=os.getenv("SKILLS_DB_PASSWORD")
-    )
 
 
 async def run_trajectory(process_id: int, config: EvalConfig):

--- a/run.py
+++ b/run.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+import asyncio
 # Add the necessary paths to sys.path
 root_dir = os.path.dirname(os.path.abspath(__file__))
 env_src_dir = os.path.join(root_dir, 'env', 'src')
@@ -12,4 +13,4 @@ if env_src_dir not in sys.path:
 # Now import and run the actual script
 from eval.open.independent_runs.run import main
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())


### PR DESCRIPTION
Moved db creation logic to db_client.py file. Added table creation logic for both postgres and sqlite in new methods, that are then called in the existing create_db_client method.

Added a new .env variable to let the user select between sqlite and postgres. Replaced Child db classes with the parent DB Client class across the project, so that the db is dynamically maintained across everywhere.

Tested manually with db creation checks, data entry checks from running lab play experiments.

updated README to reflect the simplifications made in the overall steps.