### PR TITLE
Score dump()

### DIFF
--- a/fle/env/tools/agent/score/server.lua
+++ b/fle/env/tools/agent/score/server.lua
@@ -329,6 +329,19 @@ production_score.get_production_scores = function(price_list)
   return scores
 end
 
+function dump(o)
+  if type(o) == 'table' then
+     local s = '{ '
+     for k,v in pairs(o) do
+        if type(k) ~= 'number' then k = '"'..k..'"' end
+        s = s .. '['..k..'] = ' .. dump(v) .. ','
+     end
+     return s .. '} '
+  else
+     return tostring(o)
+  end
+end
+
 global.goal = nil
 global.actions.score = function()
     local production_score = production_score.get_production_scores()


### PR DESCRIPTION
This fixes the missing "player" key in the score dict when running tests with the client connected. Need to root cause further.