### PR TITLE
Fix: Use Resource.IronOre for resource patches at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Agents interact with **FLE** by code synthesis through a **REPL** (Read-Eval-Pri
 # 1. Get iron patch and place mining drill
 drill = place_entity(
     entity=Prototype.MiningDrill,
-    position=nearest(Prototype.IronOre)),
+    position=nearest(Resource.IronOre),
     direction=Direction.NORTH
 )
 # 2. Add output storage


### PR DESCRIPTION
## Fix incorrect resource patch reference in README example

### Description
The README example incorrectly uses `Prototype.IronOre` when finding iron ore patches. According to the source code in `fle/env/game_types.py`, `Resource.IronOre` should be used for resource patches.

### Changes
- Changed `position=nearest(Prototype.IronOre))` to `position=nearest(Resource.IronOre))`

### Context
- `Prototype.IronOre` is for item operations (insert_item, extract_item, etc.)
- `Resource.IronOre` is for finding resource patches on the map (nearest(), get_resource_patch())
- All other uses of `Prototype` in the example are correct for entity placement

### Impact
This aligns the documentation with the actual API implementation and prevents confusion for developers using the FLE gym interface.