### PR TITLE
refactor: simplify gym environment registry

### DIFF
--- a/fle/env/gym_env/README.md
+++ b/fle/env/gym_env/README.md
@@ -301,4 +301,4 @@ Run the test suite to verify the registry is working correctly:
 python env/tests/gym_env/test_registry.py
 ```
 
-This registry system provides a clean, standardized interface for working with Factorio gym environments, making it easy to experiment with different tasks and integrate with existing gym-based frameworks. 
+This registry system provides a clean, standardized interface for working with Factorio gym environments, making it easy to experiment with different tasks and integrate with existing gym-based frameworks.


### PR DESCRIPTION
Remove GymEnvironmentSpec dataclass and use JSON config directly.
Replace .get() calls with direct dictionary access to fail fast on missing required fields.
Store task data directly in registry instead of duplicating fields
Use kwargs unpacking in get_environment_info() for flexibility
Replace .get() with [] access to eliminate silent defaults