### PR TITLE
remove redundant validate_run

### DIFF
--- a/fle/env/gym_env/run_eval.py
+++ b/fle/env/gym_env/run_eval.py
@@ -13,7 +13,6 @@ from fle.env.gym_env.registry import get_environment_info, list_available_enviro
 from fle.env.gym_env.trajectory_runner import GymTrajectoryRunner
 
 from fle.agents.gym_agent import GymAgent
-from fle.commons.cluster_ips import get_local_container_ips
 from fle.commons.db_client import create_db_client, get_next_version
 from fle.eval.tasks import TaskFactory
 from fle.env.utils.controller_loader.system_prompt_generator import (
@@ -37,13 +36,6 @@ def get_validated_run_configs(run_config_location: str) -> list[GymRunConfig]:
             raise ValueError(
                 f"Environment ID '{run_config.env_id}' not found in registry. Available environments: {available_envs}"
             )
-
-    # Check if we have enough containers
-    ips, udp_ports, tcp_ports = get_local_container_ips()
-    if len(tcp_ports) < len(run_configs):
-        raise ValueError(
-            f"Not enough containers for {len(run_configs)} runs. Only {len(tcp_ports)} containers available."
-        )
 
     return run_configs
 


### PR DESCRIPTION
Remove redundant get_local_container_ips call in run_eval.py

The registry.py make_factorio_env function already handles container IP discovery
via get_local_container_ips when no external server config is provided. The
get_validated_run_configs function in run_eval.py was making an unnecessary
duplicate call to this same function.

This change eliminates the redundant container IP lookup while maintaining
the same functionality, since the registry properly handles both local
container discovery and external server configuration via environment
variables.

<img width="910" height="892" alt="Screenshot 2025-08-20 at 15 16 13" src="https://github.com/user-attachments/assets/5378fd83-59f5-402d-8b8e-e73dd4c0cfe0" />

