### PR TITLE
observation_fix

### DIFF
--- a/fle/env/gym_env/observation_formatter.py
+++ b/fle/env/gym_env/observation_formatter.py
@@ -178,7 +178,7 @@ class BasicObservationFormatter:
         def clean_entity_string(entity_str: str) -> str:
             """Clean and format an entity string for better readability"""
             # Remove class references and unnecessary information
-            entity_str = entity_str.replace("class 'env.src.entities.", "")
+            entity_str = entity_str.replace("class 'fle.env.entities.", "")
             entity_str = entity_str.replace("'>", "")
 
             # Split into key-value pairs, being careful with nested structures


### PR DESCRIPTION
```
fle/env/gym_env/observation_formatter.py:line 181`:
    entity_str = entity_str.replace("class 'env.src.entities.", "")
```

uses the old path hence `observation.txt` contains fle module references:

`  - fuel=Inventory({'coal': 20}), name='boiler', direction=Direction.UP, position=Position(x=-4.5, y=5.0), id=102.0, energy=0.0, type='boiler', dimensions=(2.6, 1.6), tile_dimensions=(3.0, 2.0), prototype=Prototype.Boiler, ('boiler', <class 'fle.env.entities.Boiler)> health=200.0 warnings=['no input liquid', 'no fluid present in connections'] status=EntityStatus.NOT_CONNECTED neighbours=[Entity(name='character', direction=RIGHT, position=Position(x=-2.5 y=6.5)] connection_points=[Position(x=-6.5, y=5.5), Position(x=-2.5, y=5.5)] fluid_box=[] fluid_systems=[] steam_output_point=Position(x=-4.5, y=3.5)`

i would assume this leads to some minor confusion for the llm.