### PR TITLE
Graceful Exits

### DIFF
--- a/fle/__init__.py
+++ b/fle/__init__.py
@@ -4,3 +4,14 @@
 from fle import agents, env, eval, cluster, commons
 
 __all__ = ["agents", "env", "eval", "cluster", "commons"]
+
+# Ensure Ctrl-C exits cleanly across OSes without stack traces
+import signal
+import sys
+
+
+def _exit_on_sigint(signum, frame):
+    sys.exit(0)
+
+
+signal.signal(signal.SIGINT, _exit_on_sigint)

--- a/fle/__init__.py
+++ b/fle/__init__.py
@@ -4,14 +4,3 @@
 from fle import agents, env, eval, cluster, commons
 
 __all__ = ["agents", "env", "eval", "cluster", "commons"]
-
-# Ensure Ctrl-C exits cleanly across OSes without stack traces
-import signal
-import sys
-
-
-def _exit_on_sigint(signum, frame):
-    sys.exit(0)
-
-
-signal.signal(signal.SIGINT, _exit_on_sigint)

--- a/fle/run.py
+++ b/fle/run.py
@@ -5,10 +5,10 @@ import subprocess
 from pathlib import Path
 import importlib.resources
 import asyncio
-import signal
 from fle.env.gym_env.run_eval import main as run_eval
+import signal
 
-signal.signal(signal.SIGINT, lambda sig, frame: sys.exit(0))
+signal.signal(signal.SIGINT, lambda s, f: sys.exit(0))
 
 
 def fle_init():
@@ -49,8 +49,6 @@ def fle_eval(args):
     try:
         config_path = str(Path(args.config))
         asyncio.run(run_eval(config_path))
-    except KeyboardInterrupt:
-        sys.exit(0)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -98,7 +96,4 @@ Examples:
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except KeyboardInterrupt:
-        sys.exit(0)
+    main()

--- a/fle/run.py
+++ b/fle/run.py
@@ -5,7 +5,10 @@ import subprocess
 from pathlib import Path
 import importlib.resources
 import asyncio
+import signal
 from fle.env.gym_env.run_eval import main as run_eval
+
+signal.signal(signal.SIGINT, lambda sig, frame: sys.exit(0))
 
 
 def fle_init():

--- a/fle/run.py
+++ b/fle/run.py
@@ -49,6 +49,8 @@ def fle_eval(args):
     try:
         config_path = str(Path(args.config))
         asyncio.run(run_eval(config_path))
+    except KeyboardInterrupt:
+        sys.exit(0)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -96,4 +98,7 @@ Examples:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(0)


### PR DESCRIPTION
closes #315 

Here is how code exits gracefully now upon control + c
```
kian@sampo:~/factorio-learning-environment$ uv run -m fle.run eval --config .fle/test.json 
Using local Factorio container at 127.0.0.1:27000
Connected to 127.0.0.1 client at tcp/27000.
Initial score: 0
/home/kian/factorio-learning-environment/.venv/lib/python3.12/site-packages/gym/utils/passive_env_checker.py:31: UserWarning: WARN: A Box observation space has an unconventional shape (neither an image, nor a 1D vector). We recommend flattening the observation to have only a 1D vector or use a custom policy to properly process the data. Actual observation shape: ()
  logger.warn(
No valid programs found for version 4163 
/home/kian/factorio-learning-environment/.venv/lib/python3.12/site-packages/gym/spaces/box.py:227: UserWarning: WARN: Casting input x to numpy array.
  logger.warn("Casting input x to numpy array.")
^Ckian@sampo:~/factorio-learning-environment$ 
```