### PR TITLE
remove fle.env. from method signature

### DIFF
--- a/fle/env/utils/controller_loader/schema_generator.py
+++ b/fle/env/utils/controller_loader/schema_generator.py
@@ -39,6 +39,7 @@ class SchemaGenerator:
                 .replace("entities.", "")
                 .replace("instance.", "")
                 .replace("game_types.", "")
+                .replace("fle.env.", "")
             )
 
             docstring_element = (


### PR DESCRIPTION
removes 76 instances of  `fle.env.` from function signatures in methods section of `## Important Notes` in the system prompt

-- `inspect_inventory(entity=None, all_players: bool = False) -> Union[fle.env.Inventory, List[fle.env.Inventory]]`
++ `inspect_inventory(entity=None, all_players: bool = False) -> Union[Inventory, List[Inventory]]`
