### PR TITLE
fix: detect docker compose availability in cluster script

### DIFF
--- a/fle/cluster/run-envs.sh
+++ b/fle/cluster/run-envs.sh
@@ -35,12 +35,16 @@ setup_platform() {
 
 # Function to check for docker compose command
 setup_compose_cmd() {
+    if ! command -v docker &> /dev/null; then
+        echo "Error: Docker not found. Please install Docker."
+        exit 1
+    fi
     if docker compose version &> /dev/null; then
         COMPOSE_CMD="docker compose"
     elif command -v docker-compose &> /dev/null; then
         COMPOSE_CMD="docker-compose"
     else
-        echo "Error: Docker Compose not found. Install Docker Desktop or docker-compose."
+        echo "Error: Docker Compose not found. Please install Docker Compose."
         exit 1
     fi
 }

--- a/fle/cluster/run-envs.sh
+++ b/fle/cluster/run-envs.sh
@@ -35,10 +35,12 @@ setup_platform() {
 
 # Function to check for docker compose command
 setup_compose_cmd() {
-    if command -v docker &> /dev/null; then
+    if docker compose version &> /dev/null; then
         COMPOSE_CMD="docker compose"
+    elif command -v docker-compose &> /dev/null; then
+        COMPOSE_CMD="docker-compose"
     else
-        echo "Error: Docker not found. Please install Docker."
+        echo "Error: Docker Compose not found. Install Docker Desktop or docker-compose."
         exit 1
     fi
 }


### PR DESCRIPTION
## Summary
- `fle/cluster/run-envs.sh` assumed any `docker` install implied a working `docker compose`. On setups without the Compose plugin (e.g. Colima + Homebrew `docker` without `docker-compose`), `fle cluster start` would fall through to `docker -f docker-compose.yml up -d` and fail with the misleading `unknown shorthand flag: 'f' in -f`.
- Now checks for `docker` first (preserving the original "Docker not found" error), then verifies `docker compose version` actually works, and falls back to the standalone `docker-compose` binary if present — mirroring the detection already in `fle/cluster/run_envs.py:43-55`.

## Test plan
- [x] `bash -n fle/cluster/run-envs.sh` passes
- [x] On a machine with the Compose plugin installed, `fle cluster start` pulls the image and brings up the container as expected
- [x] On a mocked env with only standalone `docker-compose` (plugin returns non-zero), `setup_compose_cmd` selects `COMPOSE_CMD=docker-compose` and exits 0
- [x] On a mocked env with no `docker`, fails with `Error: Docker not found. Please install Docker.` and exits 1
- [x] On a mocked env with `docker` but no compose (plugin or standalone), fails with `Error: Docker Compose not found. Please install Docker Compose.` and exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)