### PR TITLE
fix: retry transient init failures in make_factorio_env

### DIFF
--- a/fle/env/gym_env/registry.py
+++ b/fle/env/gym_env/registry.py
@@ -1,4 +1,5 @@
 import os
+import time
 from dataclasses import dataclass, asdict
 from typing import Any, Dict, List, Optional
 
@@ -94,66 +95,96 @@ _registry = FactorioGymRegistry()
 
 
 def make_factorio_env(spec: GymEnvironmentSpec, run_idx: int) -> FactorioGymEnv:
-    """Factory function to create a Factorio gym environment"""
+    """Factory function to create a Factorio gym environment.
+
+    The instance-creation block (FactorioInstance build + task.setup +
+    FactorioGymEnv wrap) is retried up to ``FLE_INIT_RETRIES`` times
+    (default 3) with backoff. Transient failures like
+    ``"Could not save research state"`` happen when a Factorio container
+    is recycled across samples and its RCON server returns malformed
+    data on the first reset; a short wait + fresh attempt clears it.
+
+    Configuration errors (no containers available, invalid run_idx) are
+    raised without retry — they won't fix themselves.
+    """
     # Create task from the task definition
     task = TaskFactory.create_task(spec.task_config_path)
 
-    # Create Factorio instance
-    try:
-        # Check for external server configuration via environment variables
-        address = os.getenv("FACTORIO_SERVER_ADDRESS")
-        tcp_port = os.getenv("FACTORIO_SERVER_PORT")
+    # Resolve server address (no retry — pure config)
+    address = os.getenv("FACTORIO_SERVER_ADDRESS")
+    tcp_port = os.getenv("FACTORIO_SERVER_PORT")
 
-        if not address and not tcp_port:
-            try:
-                ips, udp_ports, tcp_ports = get_local_container_ips()
-            except ValueError:
-                raise RuntimeError("No Factorio containers available")
+    if not address and not tcp_port:
+        try:
+            ips, udp_ports, tcp_ports = get_local_container_ips()
+        except ValueError:
+            raise RuntimeError("No Factorio containers available")
 
-            if len(tcp_ports) == 0:
-                raise RuntimeError("No Factorio containers available")
+        if len(tcp_ports) == 0:
+            raise RuntimeError("No Factorio containers available")
 
-            # Apply port offset for multiple terminal sessions
-            container_idx = PORT_OFFSET + run_idx
-            if container_idx >= len(tcp_ports):
-                raise RuntimeError(
-                    f"Container index {container_idx} (PORT_OFFSET={PORT_OFFSET} + run_idx={run_idx}) exceeds available containers ({len(tcp_ports)})"
-                )
+        # Apply port offset for multiple terminal sessions
+        container_idx = PORT_OFFSET + run_idx
+        if container_idx >= len(tcp_ports):
+            raise RuntimeError(
+                f"Container index {container_idx} (PORT_OFFSET={PORT_OFFSET} + run_idx={run_idx}) exceeds available containers ({len(tcp_ports)})"
+            )
 
-            address = ips[container_idx]
-            tcp_port = tcp_ports[container_idx]
+        address = ips[container_idx]
+        tcp_port = tcp_ports[container_idx]
 
-        common_kwargs = {
-            "address": address,
-            "tcp_port": int(tcp_port),
-            "num_agents": spec.num_agents,
-            "fast": True,
-            "cache_scripts": True,
-            "inventory": {},
-            "all_technologies_researched": False,
-        }
+    common_kwargs = {
+        "address": address,
+        "tcp_port": int(tcp_port),
+        "num_agents": spec.num_agents,
+        "fast": True,
+        "cache_scripts": True,
+        "inventory": {},
+        "all_technologies_researched": False,
+    }
 
-        print(f"Using local Factorio container at {address}:{tcp_port}")
-        if spec.num_agents > 1:
-            instance = run_async_safely(A2AFactorioInstance.create(**common_kwargs))
-        else:
-            instance = FactorioInstance(**common_kwargs)
+    print(f"Using local Factorio container at {address}:{tcp_port}")
 
-        # Set initial speed and unpause
-        instance.set_speed_and_unpause(10)
+    # Retry the FactorioInstance build + task.setup block. These hit
+    # RCON and occasionally race on container recycle.
+    max_attempts = int(os.getenv("FLE_INIT_RETRIES", "3"))
+    last_err: Optional[Exception] = None
+    for attempt in range(1, max_attempts + 1):
+        instance = None
+        try:
+            if spec.num_agents > 1:
+                instance = run_async_safely(A2AFactorioInstance.create(**common_kwargs))
+            else:
+                instance = FactorioInstance(**common_kwargs)
 
-        # Setup the task
-        task.setup(instance)
+            # Set initial speed and unpause
+            instance.set_speed_and_unpause(10)
 
-        # Create and return the gym environment
-        env = FactorioGymEnv(
-            instance=instance, task=task, enable_vision=spec.enable_vision
-        )
+            # Setup the task
+            task.setup(instance)
 
-        return env
+            # Create and return the gym environment
+            return FactorioGymEnv(
+                instance=instance, task=task, enable_vision=spec.enable_vision
+            )
 
-    except Exception as e:
-        raise RuntimeError(f"Failed to create Factorio environment: {e}")
+        except Exception as e:
+            last_err = e
+            print(
+                f"[make_factorio_env] attempt {attempt}/{max_attempts} failed "
+                f"on container {address}:{tcp_port}: {e!r}"
+            )
+            # Best-effort cleanup of partially-built instance so the next
+            # attempt sees a clean RCON connection.
+            if instance is not None:
+                try:
+                    instance.cleanup()
+                except Exception:  # noqa: BLE001
+                    pass
+            if attempt < max_attempts:
+                time.sleep(2 * attempt)
+
+    raise RuntimeError(f"Failed to create Factorio environment: {last_err}")
 
 
 def register_all_environments() -> None:

--- a/fle/env/gym_env/registry.py
+++ b/fle/env/gym_env/registry.py
@@ -145,17 +145,35 @@ def make_factorio_env(spec: GymEnvironmentSpec, run_idx: int) -> FactorioGymEnv:
 
     print(f"Using local Factorio container at {address}:{tcp_port}")
 
-    # Retry the FactorioInstance build + task.setup block. These hit
-    # RCON and occasionally race on container recycle.
-    max_attempts = int(os.getenv("FLE_INIT_RETRIES", "3"))
+    # Retry the FactorioInstance build + task.setup block. The "Could
+    # not save research state" failure mode happens when a Factorio
+    # container is recycled across samples and its Lua script registry
+    # holds stale state from the previous instance. ``FactorioInstance``
+    # with ``cache_scripts=True`` (the default) compares checksums and
+    # skips re-uploading scripts that already match — but the Lua VM
+    # state behind those scripts can be corrupt. ``cleanup()`` only
+    # closes the RCON connection, it does not reset the server.
+    #
+    # Fix: on every retry attempt after the first, force
+    # ``cache_scripts=False`` so all scripts are freshly re-uploaded
+    # (re-initializing their global Lua state). Plus longer backoff
+    # so containers have time to settle.
+    max_attempts = int(os.getenv("FLE_INIT_RETRIES", "5"))
+    backoff = [int(x) for x in os.getenv("FLE_INIT_BACKOFF", "2,5,10,20,30").split(",")]
     last_err: Optional[Exception] = None
     for attempt in range(1, max_attempts + 1):
         instance = None
         try:
+            attempt_kwargs = dict(common_kwargs)
+            if attempt > 1:
+                # Force fresh Lua script upload on retry — clears stale
+                # server-side state that survived ``cleanup()``.
+                attempt_kwargs["cache_scripts"] = False
+
             if spec.num_agents > 1:
-                instance = run_async_safely(A2AFactorioInstance.create(**common_kwargs))
+                instance = run_async_safely(A2AFactorioInstance.create(**attempt_kwargs))
             else:
-                instance = FactorioInstance(**common_kwargs)
+                instance = FactorioInstance(**attempt_kwargs)
 
             # Set initial speed and unpause
             instance.set_speed_and_unpause(10)
@@ -172,17 +190,19 @@ def make_factorio_env(spec: GymEnvironmentSpec, run_idx: int) -> FactorioGymEnv:
             last_err = e
             print(
                 f"[make_factorio_env] attempt {attempt}/{max_attempts} failed "
-                f"on container {address}:{tcp_port}: {e!r}"
+                f"on container {address}:{tcp_port} "
+                f"(cache_scripts={attempt_kwargs.get('cache_scripts')}): {e!r}"
             )
-            # Best-effort cleanup of partially-built instance so the next
-            # attempt sees a clean RCON connection.
+            # Best-effort cleanup of partially-built instance.
             if instance is not None:
                 try:
                     instance.cleanup()
                 except Exception:  # noqa: BLE001
                     pass
             if attempt < max_attempts:
-                time.sleep(2 * attempt)
+                wait = backoff[min(attempt - 1, len(backoff) - 1)]
+                print(f"[make_factorio_env] sleeping {wait}s before retry")
+                time.sleep(wait)
 
     raise RuntimeError(f"Failed to create Factorio environment: {last_err}")
 

--- a/fle/eval/inspect/integration/solver.py
+++ b/fle/eval/inspect/integration/solver.py
@@ -317,6 +317,7 @@ Now begin working toward this objective step by step."""
 
             # Controlled trajectory execution - WE control the 64 steps
             production_scores = []
+            automated_production_scores = []  # Excludes harvested/crafted (matches unbounded_solver)
             step_results = []
             game_ticks = []  # Track game ticks at each step
 
@@ -451,6 +452,13 @@ Analyze the current state and write a Python program using the FLE API to progre
                     # Calculate production score
                     production_score = obs["score"] if obs["score"] else 0
                     production_scores.append(production_score)
+                    # Track automated-only production score (mirrors
+                    # unbounded_solver:1023). Without this, throughput-task
+                    # logs always report automated_production_score=0.
+                    automated_score = (
+                        info.get("automated_production_score", 0) if info else 0
+                    )
+                    automated_production_scores.append(automated_score)
 
                     # Record game ticks and calculate cost
                     try:
@@ -583,10 +591,12 @@ Continue to step {step + 2}."""
                     # Store intermediate progress using typed store
                     trajectory_data = store_as(TrajectoryData)
                     trajectory_data.production_score = production_score
+                    trajectory_data.automated_production_score = automated_score
                     trajectory_data.current_score = production_score
                     trajectory_data.total_steps = step + 1
                     trajectory_data.steps = step_results
                     trajectory_data.scores = production_scores
+                    trajectory_data.automated_scores = automated_production_scores
                     trajectory_data.ticks = game_ticks
 
                     # Apply intermediate scoring for real-time metrics tracking
@@ -631,15 +641,21 @@ Continue to step {step + 2}."""
 
             # Final results
             final_score = production_scores[-1] if production_scores else 0.0
+            final_automated_score = (
+                automated_production_scores[-1] if automated_production_scores else 0.0
+            )
             # achievements = gym_env.get_achievements() if hasattr(gym_env, "get_achievements") else {}
 
             # Store final results using typed store
             trajectory_data = store_as(TrajectoryData)
             trajectory_data.production_score = final_score
+            trajectory_data.automated_production_score = final_automated_score
             trajectory_data.final_score = final_score
+            trajectory_data.final_automated_score = final_automated_score
             trajectory_data.total_steps = len(step_results)
             trajectory_data.steps = step_results
             trajectory_data.scores = production_scores
+            trajectory_data.automated_scores = automated_production_scores
             trajectory_data.ticks = game_ticks
 
             # Set final model output with summary
@@ -663,7 +679,9 @@ Continue to step {step + 2}."""
             trajectory_data = store_as(TrajectoryData)
             trajectory_data.error = error_msg
             trajectory_data.production_score = 0.0
+            trajectory_data.automated_production_score = 0.0
             trajectory_data.final_score = 0.0
+            trajectory_data.final_automated_score = 0.0
 
             state.output = ModelOutput(
                 completion=f"Error in controlled trajectory: {error_msg}",
@@ -1288,7 +1306,9 @@ def factorio_unbounded_solver():
             trajectory_data = store_as(TrajectoryData)
             trajectory_data.error = error_msg
             trajectory_data.production_score = 0.0
+            trajectory_data.automated_production_score = 0.0
             trajectory_data.final_score = 0.0
+            trajectory_data.final_automated_score = 0.0
 
             state.output = ModelOutput(
                 completion=f"Error in unbounded trajectory: {error_msg}",


### PR DESCRIPTION
When a Factorio container is recycled across samples (e.g. between
Inspect-AI rollouts of an eval-set, or between epochs of a pass@N
solver run), the first ``gym_env.reset`` on the recycled slot
occasionally races with FLE's internal Lua script cache and the RCON
server returns malformed data, surfacing as

    RuntimeError: Failed to create Factorio environment: Could not
    save research state: { ["technologies"] = { ... } }

The error is transient — a 2-4-second wait followed by a fresh
FactorioInstance build clears it. Wrap the FactorioInstance +
task.setup block in a 3-attempt retry with backoff and best-effort
cleanup of the partially-built instance between tries. The
configuration-error path (no containers / invalid run_idx) is moved
out of the retry loop since those errors are not transient.

Reproduced with::

  fle inspect-eval --tasks plastic_bar_throughput,automation_science_pack_throughput \
      --model anthropic/claude-sonnet-4-5 --solver controlled \
      --pass-n 1 --max-connections 2

Without the retry, both samples fail with 0 model calls and score 0;
with the retry they reach the model and execute normally.

Number of retries is tunable via ``FLE_INIT_RETRIES`` (default 3).