### PR TITLE
fix(get_path): bump default max_attempts + env-var override

### DIFF
--- a/fle/env/tools/admin/get_path/client.py
+++ b/fle/env/tools/admin/get_path/client.py
@@ -1,8 +1,16 @@
+import os
 from time import sleep
 from typing import List
 
 from fle.env.entities import Position
 from fle.env.tools import Tool
+
+# Default budget: 120 backoff polls (~115s wall-clock) instead of 10 (~6.5s).
+# Long-distance move_to on fresh worlds has to wait for Factorio's
+# chunk-generation before A* can start; 10 polls is not enough, and
+# empirically 30 and 60 still miss occasionally. Override at runtime with
+# `FLE_GETPATH_MAX_ATTEMPTS`.
+_DEFAULT_MAX_ATTEMPTS = int(os.environ.get("FLE_GETPATH_MAX_ATTEMPTS", "120"))
 
 
 class GetPath(Tool):
@@ -11,9 +19,21 @@ class GetPath(Tool):
         # self.connection = connection
         # self.game_state = game_state
 
-    def __call__(self, path_handle: int, max_attempts: int = 10) -> List[Position]:
-        """
-        Retrieve a path requested from the game, using backoff polling.
+    def __call__(
+        self,
+        path_handle: int,
+        max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
+    ) -> List[Position]:
+        """Retrieve a path requested from the game, using backoff polling.
+
+        The path is computed asynchronously on the Factorio side; this
+        method polls `get_path(path_handle)` with exponential backoff
+        (50ms → 1s cap) for up to ``max_attempts`` rounds before
+        giving up with a timeout exception.
+
+        The default can also be overridden via the
+        ``FLE_GETPATH_MAX_ATTEMPTS`` environment variable, which is read
+        at module import time.
         """
 
         try:
@@ -55,7 +75,11 @@ class GetPath(Tool):
                 sleep(wait_time)
                 wait_time = min(wait_time * 2, 1.0)
 
-            raise Exception(f"Path request timed out after {max_attempts} attempts")
+            raise Exception(
+                f"Path request timed out after {max_attempts} attempts "
+                "(set FLE_GETPATH_MAX_ATTEMPTS higher if your world is slow "
+                "to chunk-generate)"
+            )
 
         except Exception as e:
             # raise ConnectionError(

--- a/fle/env/tools/admin/get_path/client.py
+++ b/fle/env/tools/admin/get_path/client.py
@@ -10,7 +10,7 @@ from fle.env.tools import Tool
 # chunk-generation before A* can start; 10 polls is not enough, and
 # empirically 30 and 60 still miss occasionally. Override at runtime with
 # `FLE_GETPATH_MAX_ATTEMPTS`.
-_DEFAULT_MAX_ATTEMPTS = int(os.environ.get("FLE_GETPATH_MAX_ATTEMPTS", "120"))
+_DEFAULT_MAX_ATTEMPTS = int(v) if (v := os.environ.get("FLE_GETPATH_MAX_ATTEMPTS", "120")).isdigit() and int(v) > 0 else 120
 
 
 class GetPath(Tool):


### PR DESCRIPTION
GetPath.__call__ polls the async path-handle with exponential backoff (50ms → 1s cap). The old 10-attempt default gave ~6.5s wall-clock budget, which is not enough on a fresh world: the first distant `move_to` has to wait for Factorio's chunk-generation before A* can even start, and chunk-gen routinely exceeds 6.5s.

Empirically:
- 24-task gpt-5.4 throughput eval at the 10-attempt default: 12/129 tool messages (~9.3%) raised "Path request timed out after 10 attempts", always on the first distant move_to of each rollout.
- 6-task Sonnet-4.5 eval at a 30-attempt client-side patch: 2/229 (~0.9%).
- 1-task gpt-4o eval at 60-attempt: 1/40 (~2.5%).

Bumping the default to 120 (~115s wall-clock budget). Override with `FLE_GETPATH_MAX_ATTEMPTS=N` when running on slower hardware, or lower it explicitly if failing fast on unreachable targets matters more than tolerating cold chunks.