### PR TITLE
Add structured summaries for connection groups

### DIFF
--- a/fle/env/entities.py
+++ b/fle/env/entities.py
@@ -975,12 +975,82 @@ class EntityGroup(BaseModel):
     position: Position
     name: str = "entity-group"
 
+    def _position_dict(
+        self, position: Optional[Position]
+    ) -> Optional[Dict[str, float]]:
+        if position is None:
+            return None
+        return {"x": position.x, "y": position.y}
+
+    def _status_name(self, status: Optional[EntityStatus]) -> Optional[str]:
+        if status is None:
+            return None
+        return status.value
+
+    def _direction_name(self, entity: Any) -> Optional[str]:
+        direction = getattr(entity, "direction", None)
+        if direction is None:
+            return None
+        return getattr(direction, "name", str(direction))
+
+    def _prototype_dict(self, prototype: Any) -> Optional[Dict[str, str]]:
+        if prototype is None:
+            return None
+        rule_name = None
+        if hasattr(prototype, "value") and isinstance(prototype.value, tuple):
+            rule_name = prototype.value[0]
+        return {
+            "id": getattr(prototype, "name", str(prototype)),
+            "name": rule_name or str(prototype),
+        }
+
+    def _inventory_dict(self, inventory: Any) -> Dict[str, Any]:
+        if inventory is None:
+            return {}
+        if isinstance(inventory, Inventory):
+            return dict(inventory.items())
+        if isinstance(inventory, dict):
+            return {
+                str(key): (
+                    self._inventory_dict(value)
+                    if isinstance(value, (Inventory, dict))
+                    else value
+                )
+                for key, value in inventory.items()
+            }
+        return {}
+
+    def _entity_dict(self, entity: Any) -> Dict[str, Any]:
+        return {
+            "name": getattr(entity, "name", None),
+            "prototype": self._prototype_dict(getattr(entity, "prototype", None)),
+            "position": self._position_dict(getattr(entity, "position", None)),
+            "direction": self._direction_name(entity),
+            "status": self._status_name(getattr(entity, "status", None)),
+            "warnings": list(getattr(entity, "warnings", []) or []),
+        }
+
+    def to_connection_dict(self) -> Dict[str, Any]:
+        """Return a stable, machine-readable summary of this connection group."""
+        return {
+            "type": self.name,
+            "id": self.id,
+            "status": self._status_name(self.status),
+            "position": self._position_dict(self.position),
+        }
+
 
 class WallGroup(EntityGroup):
     """A wall"""
 
     name: str = "wall-group"
     entities: List[Entity]
+
+    def to_connection_dict(self) -> Dict[str, Any]:
+        data = super().to_connection_dict()
+        data["entities"] = [self._entity_dict(entity) for entity in self.entities]
+        data["entity_count"] = len(self.entities)
+        return data
 
 
 class BeltGroup(EntityGroup):
@@ -998,6 +1068,33 @@ class BeltGroup(EntityGroup):
 
     def __str__(self):
         return self.__repr__()
+
+    def _belt_dict(self, belt: TransportBelt) -> Dict[str, Any]:
+        data = self._entity_dict(belt)
+        data.update(
+            {
+                "input_position": self._position_dict(belt.input_position),
+                "output_position": self._position_dict(belt.output_position),
+                "is_source": belt.is_source,
+                "is_terminus": belt.is_terminus,
+                "inventory": self._inventory_dict(belt.inventory),
+            }
+        )
+        return data
+
+    def to_connection_dict(self) -> Dict[str, Any]:
+        data = super().to_connection_dict()
+        data.update(
+            {
+                "connection_kind": "transport",
+                "inventory": self._inventory_dict(self.inventory),
+                "inputs": [self._belt_dict(entity) for entity in self.inputs],
+                "outputs": [self._belt_dict(entity) for entity in self.outputs],
+                "belts": [self._belt_dict(belt) for belt in self.belts],
+                "belt_count": len(self.belts),
+            }
+        )
+        return data
 
 
 class PipeGroup(EntityGroup):
@@ -1021,6 +1118,30 @@ class PipeGroup(EntityGroup):
     def __str__(self):
         return self.__repr__()
 
+    def _pipe_dict(self, pipe: Pipe) -> Dict[str, Any]:
+        data = self._entity_dict(pipe)
+        data.update(
+            {
+                "fluidbox_id": pipe.fluidbox_id,
+                "flow_rate": pipe.flow_rate,
+                "contents": pipe.contents,
+                "fluid": pipe.fluid,
+            }
+        )
+        return data
+
+    def to_connection_dict(self) -> Dict[str, Any]:
+        data = super().to_connection_dict()
+        data.update(
+            {
+                "connection_kind": "fluid",
+                "fluid": self.pipes[0].fluid if self.pipes else None,
+                "pipes": [self._pipe_dict(pipe) for pipe in self.pipes],
+                "pipe_count": len(self.pipes),
+            }
+        )
+        return data
+
 
 class ElectricityGroup(EntityGroup):
     """Represents a connected power network."""
@@ -1041,6 +1162,32 @@ class ElectricityGroup(EntityGroup):
 
     def __str__(self):
         return self.__repr__()
+
+    def _pole_dict(self, pole: ElectricityPole) -> Dict[str, Any]:
+        data = self._entity_dict(pole)
+        data.update(
+            {
+                "electrical_id": pole.electrical_id,
+                "flow_rate": pole.flow_rate,
+            }
+        )
+        return data
+
+    def to_connection_dict(self) -> Dict[str, Any]:
+        flow_rates = [
+            pole.flow_rate for pole in self.poles if pole.flow_rate is not None
+        ]
+        data = super().to_connection_dict()
+        data.update(
+            {
+                "connection_kind": "power",
+                "electrical_id": self.id,
+                "poles": [self._pole_dict(pole) for pole in self.poles],
+                "pole_count": len(self.poles),
+                "max_flow_rate": max(flow_rates) if flow_rates else None,
+            }
+        )
+        return data
 
 
 # =============================================================================

--- a/fle/env/tools/agent/connect_entities/agent.md
+++ b/fle/env/tools/agent/connect_entities/agent.md
@@ -64,6 +64,10 @@ belts = connect_entities(
 
 # Belt groups are returned for management
 print(f"Created belt line with {len(belts.belts)} belts")
+
+# Use structured summaries for validation or machine-readable agent logs.
+summary = belts.to_connection_dict()
+print(summary["connection_kind"], summary["belt_count"], summary["inputs"], summary["outputs"])
 ```
 
 Key points:
@@ -100,6 +104,9 @@ poles = connect_entities(
     Prototype.SmallElectricPole
 )
 print(f"Created the connection to power drill at {drill.position} with steam engine at {steam_engine.position}: {poles}")
+
+summary = poles.to_connection_dict()
+print(summary["connection_kind"], summary["pole_count"], summary["max_flow_rate"])
 ```
 
 Key points:

--- a/tests/entities/test_connection_group_summary.py
+++ b/tests/entities/test_connection_group_summary.py
@@ -1,0 +1,149 @@
+from fle.env.entities import (
+    BeltGroup,
+    Direction,
+    Dimensions,
+    ElectricityGroup,
+    ElectricityPole,
+    EntityStatus,
+    Inventory,
+    Pipe,
+    PipeGroup,
+    Position,
+    TileDimensions,
+    TransportBelt,
+)
+from fle.env.game_types import Prototype
+
+
+def _dimensions() -> Dimensions:
+    return Dimensions(width=1, height=1)
+
+
+def _tile_dimensions() -> TileDimensions:
+    return TileDimensions(tile_width=1, tile_height=1)
+
+
+def _belt(x: float, y: float, **kwargs) -> TransportBelt:
+    return TransportBelt(
+        name="transport-belt",
+        direction=kwargs.pop("direction", Direction.RIGHT),
+        position=Position(x=x, y=y),
+        energy=0,
+        dimensions=_dimensions(),
+        tile_dimensions=_tile_dimensions(),
+        prototype=Prototype.TransportBelt,
+        health=150,
+        input_position=kwargs.pop("input_position", Position(x=x - 1, y=y)),
+        output_position=kwargs.pop("output_position", Position(x=x + 1, y=y)),
+        inventory=kwargs.pop("inventory", {"left": Inventory(), "right": Inventory()}),
+        is_source=kwargs.pop("is_source", False),
+        is_terminus=kwargs.pop("is_terminus", False),
+        status=kwargs.pop("status", EntityStatus.WORKING),
+        warnings=kwargs.pop("warnings", []),
+        **kwargs,
+    )
+
+
+def _pipe(x: float, y: float, **kwargs) -> Pipe:
+    return Pipe(
+        name="pipe",
+        direction=Direction.UP,
+        position=Position(x=x, y=y),
+        energy=0,
+        dimensions=_dimensions(),
+        tile_dimensions=_tile_dimensions(),
+        prototype=Prototype.Pipe,
+        health=100,
+        status=kwargs.pop("status", EntityStatus.WORKING),
+        fluidbox_id=kwargs.pop("fluidbox_id", 7),
+        flow_rate=kwargs.pop("flow_rate", 12.5),
+        contents=kwargs.pop("contents", 88.0),
+        fluid=kwargs.pop("fluid", "water"),
+        warnings=kwargs.pop("warnings", []),
+        **kwargs,
+    )
+
+
+def _pole(x: float, y: float, **kwargs) -> ElectricityPole:
+    return ElectricityPole(
+        name="small-electric-pole",
+        direction=Direction.UP,
+        position=Position(x=x, y=y),
+        energy=0,
+        dimensions=_dimensions(),
+        tile_dimensions=_tile_dimensions(),
+        prototype=Prototype.SmallElectricPole,
+        health=100,
+        status=kwargs.pop("status", EntityStatus.NORMAL),
+        electrical_id=kwargs.pop("electrical_id", 3),
+        flow_rate=kwargs.pop("flow_rate", 42.0),
+        warnings=kwargs.pop("warnings", []),
+        **kwargs,
+    )
+
+
+def test_belt_group_connection_summary_is_machine_readable():
+    source = _belt(0, 0, is_source=True, inventory={"left": Inventory(coal=2)})
+    middle = _belt(1, 0)
+    output = _belt(2, 0, is_terminus=True, inventory={"right": Inventory(iron_ore=1)})
+    group = BeltGroup(
+        id=0,
+        position=source.position,
+        status=EntityStatus.WORKING,
+        belts=[source, middle, output],
+        inputs=[source],
+        outputs=[output],
+        inventory=Inventory(coal=2, iron_ore=1),
+    )
+
+    summary = group.to_connection_dict()
+
+    assert summary["type"] == "belt-group"
+    assert summary["connection_kind"] == "transport"
+    assert summary["status"] == "working"
+    assert summary["belt_count"] == 3
+    assert summary["inventory"] == {"coal": 2, "iron_ore": 1}
+    assert summary["inputs"][0]["position"] == {"x": 0.0, "y": 0.0}
+    assert summary["outputs"][0]["is_terminus"] is True
+    assert summary["belts"][0]["prototype"] == {
+        "id": "TransportBelt",
+        "name": "transport-belt",
+    }
+
+
+def test_pipe_group_connection_summary_is_machine_readable():
+    pipes = [_pipe(0, 0), _pipe(1, 0, contents=40.0)]
+    group = PipeGroup(
+        id=7,
+        position=pipes[0].position,
+        status=EntityStatus.WORKING,
+        pipes=pipes,
+    )
+
+    summary = group.to_connection_dict()
+
+    assert summary["type"] == "pipe-group"
+    assert summary["connection_kind"] == "fluid"
+    assert summary["fluid"] == "water"
+    assert summary["pipe_count"] == 2
+    assert summary["pipes"][0]["fluidbox_id"] == 7
+    assert summary["pipes"][0]["flow_rate"] == 12.5
+
+
+def test_electricity_group_connection_summary_is_machine_readable():
+    poles = [_pole(0, 0, flow_rate=10.0), _pole(5, 0, flow_rate=25.0)]
+    group = ElectricityGroup(
+        id=3,
+        position=Position(x=2.5, y=0),
+        status=EntityStatus.WORKING,
+        poles=poles,
+    )
+
+    summary = group.to_connection_dict()
+
+    assert summary["type"] == "electricity-group"
+    assert summary["connection_kind"] == "power"
+    assert summary["electrical_id"] == 3
+    assert summary["pole_count"] == 2
+    assert summary["max_flow_rate"] == 25.0
+    assert summary["poles"][1]["position"] == {"x": 5.0, "y": 0.0}


### PR DESCRIPTION
## Problem

When agents use FLE through the MCP/REPL workflow, `connect_entities(...)` returns rich Python objects such as `BeltGroup`, `PipeGroup`, and `ElectricityGroup`. Those objects are useful interactively, but their default string output is hard for an agent to validate programmatically.

For example, an agent can see that a route exists, but to answer basic questions like these it currently has to inspect attributes manually or parse repr text:

- how many belts/pipes/poles were placed?
- where are the route inputs and outputs?
- which direction does each belt face?
- is the group working, empty, or blocked/full?
- what inventory/fluid/power state is visible on the connection?

That makes route validation brittle in agent code and in MCP logs.

## Change

This PR adds a non-breaking structured summary method to connection group models:

```python
connection = connect_entities(source, target, Prototype.TransportBelt)
summary = connection.to_connection_dict()
```

The existing object attributes and `__repr__`/`str(...)` behavior are preserved. This only adds an explicit machine-readable representation for agents and tests.

Implemented summaries for:

- `BeltGroup`: connection kind, status, aggregate inventory, input/output belts, per-belt positions, directions, lane inventories, source/terminus flags, and belt count
- `PipeGroup`: connection kind, status, fluid, per-pipe positions, flow rate, contents, fluidbox IDs, and pipe count
- `ElectricityGroup`: connection kind, status, electrical network ID, per-pole positions, flow rates, max flow rate, and pole count
- `WallGroup`: entity list and count

## Why this shape

This does not add a new MCP tool or change the MCP protocol surface. FLE's MCP interface is already REPL-oriented, so agents receive and manipulate these Python objects inside `execute(code)`. Adding `to_connection_dict()` gives agents a stable validation surface without breaking existing callers or forcing string parsing.

A separate follow-up could expose similar structured data automatically in MCP responses or add structured failure details for blocked routes. This PR focuses only on successful connection group summaries.

## Example

```python
belts = connect_entities(drill.drop_position, inserter.pickup_position, Prototype.TransportBelt)
summary = belts.to_connection_dict()
assert summary["connection_kind"] == "transport"
assert summary["belt_count"] == len(belts.belts)
print(summary["inputs"], summary["outputs"])
```

## Testing

```bash
.venv/bin/python -m pytest tests/entities/test_connection_group_summary.py -q
.venv/bin/python -m py_compile fle/env/entities.py tests/entities/test_connection_group_summary.py
git diff --check
```