### PR TITLE
fix: resolve the inspect CLI from the running interpreter's environment

### DIFF
--- a/fle/run.py
+++ b/fle/run.py
@@ -64,13 +64,26 @@ def fle_inspect_eval(args):
         _eval_set_path = str(_eval_integration_dir / "eval_set.py")
     _agent_task_path = str(_eval_integration_dir / "agent_task.py")
 
+    # Resolve the `inspect` CLI from the interpreter running `fle`, so the
+    # subprocess works even when the venv's bin dir is not on PATH.
+    _venv_inspect = Path(sys.executable).parent / "inspect"
+    _inspect_bin = (
+        str(_venv_inspect) if _venv_inspect.exists() else shutil.which("inspect")
+    )
+    if not _inspect_bin:
+        print(
+            "Error: could not find the `inspect` CLI. Is inspect-ai installed?",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     view_process = None
 
     try:
         # Start inspect view first if requested (in background)
         if args.view:
             print(f"Starting Inspect view on port {args.view_port}...")
-            view_cmd = ["inspect", "view", "--port", str(args.view_port)]
+            view_cmd = [_inspect_bin, "view", "--port", str(args.view_port)]
             if args.log_dir:
                 view_cmd.extend(["--log-dir", args.log_dir])
             else:
@@ -110,18 +123,18 @@ def fle_inspect_eval(args):
             if len(task_names) == 1:
                 # Single task
                 cmd = [
-                    "inspect",
+                    _inspect_bin,
                     "eval",
                     f"{_eval_set_path}@{task_names[0]}",
                 ]
             else:
                 # Multiple tasks - pass each as a separate argument
                 task_specs = [f"{_eval_set_path}@{t}" for t in task_names]
-                cmd = ["inspect", "eval"] + task_specs
+                cmd = [_inspect_bin, "eval"] + task_specs
         elif args.eval_set_file:
             # Use custom eval-set file
             cmd = [
-                "inspect",
+                _inspect_bin,
                 "eval-set",
                 args.eval_set_file,
             ]
@@ -129,7 +142,7 @@ def fle_inspect_eval(args):
         elif args.eval_set:
             # Use eval-set for multiple tasks
             cmd = [
-                "inspect",
+                _inspect_bin,
                 "eval-set",
                 _eval_set_path,
             ]
@@ -137,7 +150,7 @@ def fle_inspect_eval(args):
             # Use unbounded production task
             task_name = args.env_id if args.env_id else "open_play_production"
             cmd = [
-                "inspect",
+                _inspect_bin,
                 "eval",
                 f"{_eval_set_path}@{task_name}",
             ]
@@ -145,14 +158,14 @@ def fle_inspect_eval(args):
         elif args.env_id:
             # Use specific task from eval set
             cmd = [
-                "inspect",
+                _inspect_bin,
                 "eval",
                 f"{_eval_set_path}@{args.env_id}",
             ]
         else:
             # Use the working controlled solver via agent_task.py
             cmd = [
-                "inspect",
+                _inspect_bin,
                 "eval",
                 f"{_agent_task_path}@factorio_agent_evaluation",
             ]


### PR DESCRIPTION
## Problem

`fle inspect-eval` builds its subprocess commands with a bare `inspect` executable name. When the venv's `bin` directory is not on `PATH` (e.g. calling `.venv/bin/fle` directly, or from a supervisor/cron), the run fails immediately:

```
Error: [Errno 2] No such file or directory: 'inspect'
```

This is the same class of issue as #362, which made the task-file paths absolute but left the `inspect` binary itself resolved via `PATH`.

## Fix

Resolve the `inspect` CLI next to `sys.executable` (the interpreter running `fle`, i.e. the same environment where `inspect-ai` is installed), falling back to `shutil.which`, and fail with a clear error message when neither resolves. Applies to all `inspect eval` / `eval-set` / `view` subprocess invocations in `fle_inspect_eval`.

## Testing

- With the venv **off** `PATH`: `.venv/bin/fle inspect-eval ...` now launches `inspect` correctly (previously failed with Errno 2).
- Full run: `fle inspect-eval --env-id iron_ore_throughput --sandbox --epochs 8` completes, status `success`, 8/8 samples scored.