### PR TITLE
fix(cli): don't crash when --model is omitted from fle inspect-eval

### DIFF
--- a/fle/run.py
+++ b/fle/run.py
@@ -191,11 +191,10 @@ def fle_inspect_eval(args):
         if hasattr(args, "limit") and args.limit:
             cmd.extend(["--limit", str(args.limit)])
 
-        if args.model:
-            cmd.extend(["--model", args.model])
-        else:
+        if not args.model:
             # Default to a working model for testing
-            cmd.extend(["--model", "openai/gpt-4o-mini"])
+            args.model = "openai/gpt-4o-mini"
+        cmd.extend(["--model", args.model])
 
         # Add reasoning configuration for reasoning models
         if hasattr(args, "reasoning_effort") and args.reasoning_effort:


### PR DESCRIPTION
## Problem

`fle inspect-eval` without an explicit `--model` always crashes before launching:

```
$ fle inspect-eval --env-id iron_plate_throughput
Error: argument of type 'NoneType' is not iterable
```

The openrouter check near the bottom of the command builder does `"openrouter" in args.model` while `args.model` defaults to `None` — the documented default (`openai/gpt-4o-mini`) was only ever appended to the subprocess command, never assigned back to `args.model`.

## Fix

Assign the default back to `args.model` instead of only appending it, so the openrouter check and the `FLE_MODEL` env var both see the model actually being used.

## Verification

Reproduced the crash on main, then confirmed the same invocation proceeds to `Running: inspect eval ... --model openai/gpt-4o-mini ...` after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)