### PR TITLE
fix(examples): repoint example agent imports at examples.agents

### DIFF
--- a/examples/agents/backtracking_system.py
+++ b/examples/agents/backtracking_system.py
@@ -8,8 +8,8 @@ from fle.env.namespace import FactorioNamespace
 from fle.agents.models import CompletionResult, Response
 from fle.agents.llm.parsing import Policy
 from fle.agents.agent_abc import AgentABC
-from fle.agents.backtracking_agent import BacktrackingAgent
-from fle.agents.basic_agent import BasicAgent
+from examples.agents.backtracking_agent import BacktrackingAgent
+from examples.agents.basic_agent import BasicAgent
 
 
 class BacktrackingSystem(AgentABC):

--- a/examples/agents/visual_agent.py
+++ b/examples/agents/visual_agent.py
@@ -5,7 +5,7 @@ from tenacity import retry_if_exception_type, wait_exponential
 
 from fle.agents.llm.parsing import Policy
 from fle.agents.agent_abc import AgentABC
-from fle.agents.basic_agent import FINAL_INSTRUCTION, GENERAL_INSTRUCTIONS
+from examples.agents.basic_agent import FINAL_INSTRUCTION, GENERAL_INSTRUCTIONS
 from fle.agents.formatters import RecursiveReportFormatter
 from fle.agents.models import CompletionResult, Response
 from fle.commons.models.conversation import Conversation

--- a/tests/examples/test_example_agent_imports.py
+++ b/tests/examples/test_example_agent_imports.py
@@ -1,0 +1,22 @@
+"""The shipped example agents must at least be importable.
+
+Regression test for the example modules importing BasicAgent and
+BacktrackingAgent from fle.agents.*, where they do not exist (the
+implementations live in examples/agents/).
+"""
+
+import importlib
+
+import pytest
+
+EXAMPLE_AGENT_MODULES = [
+    "examples.agents.basic_agent",
+    "examples.agents.backtracking_agent",
+    "examples.agents.backtracking_system",
+    "examples.agents.visual_agent",
+]
+
+
+@pytest.mark.parametrize("module_name", EXAMPLE_AGENT_MODULES)
+def test_example_agent_module_imports(module_name: str) -> None:
+    importlib.import_module(module_name)


### PR DESCRIPTION
## Problem

`examples/agents/backtracking_system.py` and `examples/agents/visual_agent.py` import `BasicAgent`, `BacktrackingAgent`, and the prompt constants from `fle.agents.*`, but those modules live in `examples/agents/` (`fle/agents` only contains `agent_abc`, `gym_agent`, and `models`). Both files fail to import:

```
ModuleNotFoundError: No module named 'fle.agents.backtracking_agent'
ModuleNotFoundError: No module named 'fle.agents.basic_agent'
```

## Fix

Use the `examples.agents.*` paths, matching how `tests/multiagent/test_messages.py` already imports `BasicAgent`.

## Verification

All four example agent modules (`basic_agent`, `backtracking_agent`, `backtracking_system`, `visual_agent`) now import cleanly from the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)