### PR TITLE
fix(mcp): make the [mcp] extra installable and the server constructible

### DIFF
--- a/fle/env/protocols/_mcp/__init__.py
+++ b/fle/env/protocols/_mcp/__init__.py
@@ -1,6 +1,8 @@
 """MCP protocol implementation for Factorio Learning Environment."""
 
 # ruff: noqa: E402
+from __future__ import annotations
+
 from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -8,15 +10,29 @@ from dataclasses import dataclass
 try:
     from fastmcp import FastMCP
 
-    # Create the MCP server instance FIRST
-    mcp = FastMCP(
-        "Factorio Learning Environment",
-        dependencies=["dulwich", "numpy", "pillow"],
-    )
     _FASTMCP_AVAILABLE = True
 except ImportError:
-    mcp = None
+    FastMCP = None
     _FASTMCP_AVAILABLE = False
+
+
+@asynccontextmanager
+async def fle_lifespan(server) -> AsyncIterator[FactorioContext]:
+    """Manage the Factorio server lifecycle within the MCP session"""
+    connection_message = await initialize_session()
+    context = FactorioContext(connection_message=connection_message, state=state)
+    try:
+        yield context
+    finally:
+        await shutdown_session()
+
+
+# Create the MCP server instance FIRST; the lifespan must be passed to the
+# constructor (assigning it as an attribute afterwards is ignored by fastmcp).
+if _FASTMCP_AVAILABLE:
+    mcp = FastMCP("Factorio Learning Environment", lifespan=fle_lifespan)
+else:
+    mcp = None
 
 # Now import other modules that use mcp
 if _FASTMCP_AVAILABLE:
@@ -35,21 +51,6 @@ class FactorioContext:
 
     connection_message: str
     state: FactorioMCPState
-
-
-@asynccontextmanager
-async def fle_lifespan(server) -> AsyncIterator[FactorioContext]:
-    """Manage the Factorio server lifecycle within the MCP session"""
-    connection_message = await initialize_session()
-    context = FactorioContext(connection_message=connection_message, state=state)
-    try:
-        yield context
-    finally:
-        await shutdown_session()
-
-
-# Attach the lifespan to mcp
-mcp.lifespan = fle_lifespan
 
 
 # Export mcp for other modules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,8 @@ all = [
     "scikit-image>=0.25.2",
 ]
 mcp = [
-    "mcp[cli]",
+    "mcp[cli]>=1.24.0,<2",
+    "fastmcp>=2.14.0",
     "dulwich",
 ]
 env = [


### PR DESCRIPTION
## Problem

Three issues prevent the MCP server from starting from a fresh `pip install .[mcp]`:

1. **`fastmcp` is undeclared.** `fle/env/protocols/_mcp/__init__.py` and `fle/mcp_dataloader.py` import it, but the `mcp` extra only lists `mcp[cli]` and `dulwich`, so the package falls into the (broken, see 3) fallback path.
2. **Unpinned `mcp` resolves to 2.0**, which removed `McpError` from `mcp.shared.exceptions` and breaks fastmcp at import (fastmcp 2.14 only requires `mcp>=1.24` with no upper bound).
3. **Server construction fails and the fallback crashes.** Current fastmcp releases removed the `dependencies` constructor kwarg, so `FastMCP(..., dependencies=[...])` raises `TypeError` — which the `except ImportError` guard doesn't catch. And when fastmcp is genuinely missing, the module still crashes on `mcp.lifespan = fle_lifespan` with `mcp = None`. Additionally, fastmcp only honours a lifespan passed to the **constructor** (stored in `_lifespan` at init), so the post-hoc attribute assignment was silently ignored even when it didn't crash — sessions would run without the Factorio lifecycle manager.

## Fix

- Declare `fastmcp>=2.14.0` and pin `mcp[cli]>=1.24.0,<2` in the `mcp` extra.
- Define `fle_lifespan` before the server is created and pass it as the `lifespan` constructor kwarg (its late-bound module globals resolve by the time a session starts). The no-fastmcp fallback now imports cleanly with `mcp = None`.

## Verification

- `uv pip install -e '.[mcp]'` resolves and installs (previously missing fastmcp entirely).
- `FastMCP('probe', lifespan=fle_lifespan)` constructs and `_lifespan` is wired.
- Fallback path verified by blocking the fastmcp import: module imports cleanly with `mcp = None`.
- Full end-to-end (tools served against a running cluster) not yet exercised: importing the package eagerly builds `FactorioMCPState` at import time, which requires live Factorio containers — arguably its own issue. A fresh install additionally hits the a2a-sdk 1.x API break addressed by #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)