### PR TITLE
fix(solver): don't send OpenRouter transforms to every provider

### DIFF
--- a/fle/eval/inspect/integration/solver.py
+++ b/fle/eval/inspect/integration/solver.py
@@ -385,15 +385,18 @@ Analyze the current state and write a Python program using the FLE API to progre
                     # Generate response using Inspect's model with reasoning support
                     generation_config = {
                         "max_tokens": 4096,  # More tokens for complex programs
-                        "transforms": ["middle-out"],
                         "reasoning_effort": "minimal",
                         # "temperature": 0.1
                     }
 
-                    state.output = await get_model().generate(
+                    _model = get_model()
+                    model_name_str = getattr(_model, "name", "") or ""
+                    if "openrouter" in model_name_str:
+                        generation_config["transforms"] = ["middle-out"]
+
+                    state.output = await _model.generate(
                         input=state.messages,
                         config=generation_config,
-                        # transforms = ['middle-out']
                     )
 
                     # Log reasoning usage if available


### PR DESCRIPTION
## Problem

`factorio_controlled_solver` hardcodes `'transforms': ['middle-out']` into the `GenerateConfig` for every generate call. `transforms` is an OpenRouter-specific option, and current inspect-ai validates `GenerateConfig` strictly, so **every step of every lab-play run fails** with:

```
Value error, Unknown GenerateConfig field(s): transforms. Use extra_body for provider-specific options.
```

The model is never called and every task scores 0, regardless of provider.

## Fix

Guard the option behind an openrouter model-name check, matching the pattern already used at the other generate sites in `solver.py` and `solver_variants.py`.

Note: on current inspect-ai the guarded sites will also need migrating to `extra_body` for OpenRouter runs (per the validation error's guidance). Left out of scope here since it changes OpenRouter-path behavior; happy to follow up.

## Verification

Before: an `fle inspect-eval` run (iron_plate_throughput, deepseek-v4-flash via `openai-api/`) logged the validation error at every step, zero assistant messages, score 0. After: the same run completes with the model responding normally (score 1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)