### PR TITLE
feat(cli): add --model-base-url passthrough to fle inspect-eval

### DIFF
--- a/fle/run.py
+++ b/fle/run.py
@@ -197,6 +197,9 @@ def fle_inspect_eval(args):
             # Default to a working model for testing
             cmd.extend(["--model", "openai/gpt-4o-mini"])
 
+        if getattr(args, "model_base_url", None):
+            cmd.extend(["--model-base-url", args.model_base_url])
+
         # Add reasoning configuration for reasoning models
         if hasattr(args, "reasoning_effort") and args.reasoning_effort:
             cmd.extend(["--reasoning-effort", args.reasoning_effort])
@@ -622,6 +625,12 @@ Examples:
     )
     parser_inspect.add_argument(
         "--model", help="Model to use for evaluation (e.g., openai/gpt-4o-mini)"
+    )
+    parser_inspect.add_argument(
+        "--model-base-url",
+        help="Base URL for the model API, passed through to inspect eval. "
+        "Use with an openai-api/... model to target local or self-hosted "
+        "OpenAI-compatible endpoints (e.g. vLLM, LM Studio, llama-server)",
     )
     parser_inspect.add_argument(
         "--env-id", help="Specific environment/task to evaluate (default: all tasks)"


### PR DESCRIPTION
## Motivation

`inspect eval` natively accepts `--model-base-url`, but `fle inspect-eval` provides no way to forward it, so pointing a run at a local or self-hosted OpenAI-compatible endpoint (vLLM, LM Studio, llama-server) — or a hosted OpenAI-compatible API not in the provider list — requires exporting provider-specific env vars instead of a CLI flag.

## Change

Forward `--model-base-url` to `inspect eval` when provided.

```
fle inspect-eval --env-id iron_plate_throughput \
  --model openai-api/deepseek/deepseek-v4-flash \
  --model-base-url https://api.deepseek.com/v1
```

## Verification

Live run with the invocation above (deepseek-v4-flash) resolved through Inspect's `OpenAICompatibleAPI`, executed a full trajectory against a Factorio container, and scored normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)