### PR TITLE
Preserve full Lua tool error messages

### DIFF
--- a/fle/env/tools/tool.py
+++ b/fle/env/tools/tool.py
@@ -1,8 +1,11 @@
+import re
 from typing import Tuple, Union
 
 from fle.env.entities import Position, Entity
 from fle.env.namespace import FactorioNamespace
 from fle.env.tools.controller import Controller
+
+_LUA_SOURCE_PREFIX = re.compile(r"^(?:\[string [^\r\n]*\]|[^\r\n]*\.lua):\d+:\s*")
 
 
 class Tool(Controller):
@@ -28,18 +31,22 @@ class Tool(Controller):
 
         return x, y
 
-    def get_error_message(self, response):
-        try:
-            msg = (
-                response.split(":")[-1]
-                .replace('"', "")
-                .strip()
-                .replace("\\'", "")
-                .replace("'", "")
-            )
-            return msg
-        except Exception:
-            return response
+    def get_error_message(self, response: str) -> str:
+        """Remove the Lua source prefix without truncating the error itself."""
+        if not isinstance(response, str):
+            return str(response)
+
+        # Factorio errors normally start with a Lua source and line number, for
+        # example: [string "..."]:148: "No item in inventory: ...".  Splitting
+        # on every colon loses useful parts of the actual error message.
+        prefix = _LUA_SOURCE_PREFIX.match(response)
+        message = response[prefix.end() :] if prefix else response
+        message = message.strip()
+
+        if len(message) >= 2 and message[0] == message[-1] and message[0] in {'"', "'"}:
+            message = message[1:-1]
+
+        return message.replace(r"\'", "'").replace(r"\"", '"')
 
     def load(self):
         # self.lua_script_manager.load_action_into_game(self.name)

--- a/tests/actions/test_tool_error_message.py
+++ b/tests/actions/test_tool_error_message.py
@@ -1,0 +1,41 @@
+from fle.env.tools.tool import Tool
+
+
+def parse_error(response: str) -> str:
+    return Tool.get_error_message(object.__new__(Tool), response)
+
+
+def test_error_message_preserves_inventory_reason_and_contents() -> None:
+    response = (
+        '[string "storage.actions.place_entity"]:148: '
+        '"No solar_panel in inventory. Current inventory: '
+        'wooden-chest=9, boiler=2"'
+    )
+
+    assert parse_error(response) == (
+        "No solar_panel in inventory. Current inventory: wooden-chest=9, boiler=2"
+    )
+
+
+def test_error_message_without_lua_prefix_is_not_split_at_colon() -> None:
+    response = "Current inventory: wooden-chest=9, boiler=2"
+
+    assert parse_error(response) == response
+
+
+def test_error_message_preserves_apostrophes_and_inner_colons() -> None:
+    response = r'''[string "place_entity"]:12: "solar_panel isn't placeable: blocked by entity"'''
+
+    assert parse_error(response) == "solar_panel isn't placeable: blocked by entity"
+
+
+def test_error_message_strips_file_path_prefix() -> None:
+    response = "__fle__/tools/place_entity/server.lua:148: placement failed"
+
+    assert parse_error(response) == "placement failed"
+
+
+def test_error_message_does_not_treat_message_error_code_as_source_prefix() -> None:
+    response = "Factorio error code:12: placement failed"
+
+    assert parse_error(response) == response


### PR DESCRIPTION
Existing split on colon discarded part of the error message if it contained colon by itself. Instead, we use regex to only discard the lua part