### PR TITLE
Fix reused task technology reset policy

### DIFF
--- a/fle/eval/tasks/task_abc.py
+++ b/fle/eval/tasks/task_abc.py
@@ -61,6 +61,8 @@ class TaskABC:
     def setup(self, instance):
         """setup function"""
         instance.initial_inventory = self.starting_inventory
+        # Persist the task's reset policy on the instance.
+        instance.all_technologies_researched = self.all_technology_reserached
         instance.reset(all_technologies_researched=self.all_technology_reserached)
         self.setup_instance(instance)
         self.starting_game_state = GameState.from_instance(instance)

--- a/tests/eval/test_task_abc_reset_policy.py
+++ b/tests/eval/test_task_abc_reset_policy.py
@@ -1,0 +1,36 @@
+from fle.commons.models.game_state import GameState
+from fle.eval.tasks.task_abc import TaskABC
+
+
+class RecordingTaskInstance:
+    def __init__(self) -> None:
+        self.initial_inventory = {}
+        self.all_technologies_researched = False
+        self.effective_reset_values: list[bool] = []
+
+    def reset(self, all_technologies_researched: bool | None = None) -> None:
+        effective_value = (
+            self.all_technologies_researched
+            if all_technologies_researched is None
+            else all_technologies_researched
+        )
+        self.effective_reset_values.append(effective_value)
+
+
+def test_task_setup_persists_technology_policy_for_later_reset(monkeypatch) -> None:
+    monkeypatch.setattr(GameState, "from_instance", lambda instance: object())
+    instance = RecordingTaskInstance()
+    task = TaskABC(
+        trajectory_length=64,
+        starting_inventory={"oil-refinery": 5},
+        goal_description="test",
+        task_key="test",
+        all_technology_reserached=True,
+    )
+
+    task.setup(instance)
+    instance.reset()
+
+    assert instance.initial_inventory == {"oil-refinery": 5}
+    assert instance.all_technologies_researched is True
+    assert instance.effective_reset_values == [True, True]


### PR DESCRIPTION
`all_technologies_researched` wasn't saved in the instance, resulting in wrong value on reset