### PR TITLE
Release 0.4.5: CLI and Python-compat fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Factorio Learning Environment will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.5] - 2026-09-03
+
+### Fixed
+
+- Restore Python <3.12 compatibility in `solver_variants.py` (f-string expressions cannot contain backslashes before PEP 701; the repo supports Python >=3.10) (#389)
+- `fle inspect-eval` no longer crashes with a `TypeError` when `--model` is omitted; the default model is assigned before use (#385)
+
 ## [0.4.4] - 2026-09-03
 
 ### Fixed

--- a/fle/__init__.py
+++ b/fle/__init__.py
@@ -5,7 +5,7 @@ import warnings
 
 warnings.filterwarnings("ignore", category=SyntaxWarning, module="slpp")
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 
 # Make submodules available
 from fle import agents, env, eval, cluster, commons

--- a/fle/eval/inspect/integration/solver_variants.py
+++ b/fle/eval/inspect/integration/solver_variants.py
@@ -322,12 +322,13 @@ Now begin building your factory step by step."""
 
                 else:
                     # Standard mode: append to message history
+                    game_state_str = obs_formatted.raw_str.replace("\\n", "\n")
                     step_content = f"""\n\n## Step {step + 1}/{trajectory_length} - Game State Analysis
 
 Progress: {(step / trajectory_length) * 100:.1f}% of trajectory complete
 
 **Current Game State:**
-{obs_formatted.raw_str.replace("\\n", "\n")}"""
+{game_state_str}"""
 
                     step_message = ChatMessageUser(content=step_content)
                     state.messages.append(step_message)
@@ -1533,12 +1534,13 @@ Now begin building your factory step by step."""
                     current_score = production_scores[-1] if production_scores else 0
 
                     # Create step message with full observation (only current step gets full context)
+                    game_state_str = obs_formatted.raw_str.replace("\\n", "\n")
                     step_content = f"""\n\n## Step {step + 1}/{trajectory_length} - Game State Analysis
 
 Progress: {(step / trajectory_length) * 100:.1f}% of trajectory complete
 
 **Current Game State:**
-{obs_formatted.raw_str.replace("\\n", "\n")}
+{game_state_str}
 
 **Next Action Required:**
 Analyze the current state and write a Python program using the FLE API to expand and improve your factory."""
@@ -2097,12 +2099,13 @@ Now begin building your factory step by step."""
                     current_score = production_scores[-1] if production_scores else 0
 
                     # Create step message with full observation
+                    game_state_str = obs_formatted.raw_str.replace("\\n", "\n")
                     step_content = f"""\n\n## Step {step + 1}/{trajectory_length} - Game State Analysis
 
 Progress: {(step / trajectory_length) * 100:.1f}% of trajectory complete
 
 **Current Game State:**
-{obs_formatted.raw_str.replace("\\n", "\n")}
+{game_state_str}
 
 **Next Action Required:**
 Analyze the current state and write a Python program using the FLE API to expand and improve your factory."""
@@ -2604,12 +2607,13 @@ def factorio_condensed_prompt_latest_image_solver():
                     current_score = production_scores[-1] if production_scores else 0
 
                     # Create step message
+                    game_state_str = obs_formatted.raw_str.replace("\\n", "\n")
                     step_content = f"""\n\n## Step {step + 1}/{trajectory_length} - Game State Analysis
 
 Progress: {(step / trajectory_length) * 100:.1f}% of trajectory complete
 
 **Current Game State:**
-{obs_formatted.raw_str.replace("\\n", "\n")}
+{game_state_str}
 
 **Next Action Required:**
 Analyze the current state and write a Python program using the FLE API to expand and improve your factory."""
@@ -3053,12 +3057,13 @@ def factorio_condensed_prompt_solver():
                     current_score = production_scores[-1] if production_scores else 0
 
                     # Create step message
+                    game_state_str = obs_formatted.raw_str.replace("\\n", "\n")
                     step_content = f"""\n\n## Step {step + 1}/{trajectory_length} - Game State Analysis
 
 Progress: {(step / trajectory_length) * 100:.1f}% of trajectory complete
 
 **Current Game State:**
-{obs_formatted.raw_str.replace("\\n", "\n")}
+{game_state_str}
 
 **Next Action Required:**
 Analyze the current state and write a Python program using the FLE API to expand and improve your factory."""

--- a/fle/run.py
+++ b/fle/run.py
@@ -191,11 +191,10 @@ def fle_inspect_eval(args):
         if hasattr(args, "limit") and args.limit:
             cmd.extend(["--limit", str(args.limit)])
 
-        if args.model:
-            cmd.extend(["--model", args.model])
-        else:
+        if not args.model:
             # Default to a working model for testing
-            cmd.extend(["--model", "openai/gpt-4o-mini"])
+            args.model = "openai/gpt-4o-mini"
+        cmd.extend(["--model", args.model])
 
         # Add reasoning configuration for reasoning models
         if hasattr(args, "reasoning_effort") and args.reasoning_effort:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "factorio-learning-environment"
-version = "0.4.4"
+version = "0.4.5"
 description = "Factorio Learning Environment"
 authors = [
     {name = "Jack Hopkins", email = "noreply@github.com"},


### PR DESCRIPTION
Staging branch for v0.4.5, squash-merging two verified fixes, plus version bump and changelog.

## Included PRs
- #389 — restore Python <3.12 compatibility in solver_variants.py (f-string backslash SyntaxError on 3.10/3.11, both supported by requires-python >=3.10)
- #385 — fle inspect-eval no longer crashes with TypeError when --model is omitted

## Verification
- Both bugs reproduced on current main (post-#403) before applying: py_compile fails under Python 3.11 on main and compiles clean with #389; the None model path at fle/run.py:227 confirmed and fixed by #385
- Both merge cleanly onto v0.4.4 main; ruff check and format pass with CI's version (0.11.13)

Note: squashed source PRs (#389, #385) will not auto-close — close them manually after merging.