### PR TITLE
Release 0.4.6: CLI, MCP packaging, and cluster script fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the Factorio Learning Environment will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.6] - 2026-09-03
+
+### Fixed
+
+- Example agents import from `examples.agents` instead of the nonexistent `fle.agents` modules (#386)
+- `fle inspect-eval --solver` now exposes `hud_text_only`, `fat_hud`, and `pruned_gamestate`, matching `SOLVER_MAP` (with a sync test) (#387)
+- The `[mcp]` extra is installable (declares `fastmcp>=2.14.0`, pins `mcp[cli]>=1.24.0,<2`) and the MCP server's lifespan is attached via the `FastMCP` constructor instead of a silently ignored post-hoc assignment (#388)
+- `fle/cluster/run-envs.sh` falls back to the standalone `docker-compose` binary when the `docker compose` plugin is unavailable (#365)
+
+### Added
+
+- `--model-base-url` passthrough on `fle inspect-eval` for custom model API endpoints (#391)
+
 ## [0.4.5] - 2026-09-03
 
 ### Fixed

--- a/examples/agents/backtracking_system.py
+++ b/examples/agents/backtracking_system.py
@@ -8,8 +8,8 @@ from fle.env.namespace import FactorioNamespace
 from fle.agents.models import CompletionResult, Response
 from fle.agents.llm.parsing import Policy
 from fle.agents.agent_abc import AgentABC
-from fle.agents.backtracking_agent import BacktrackingAgent
-from fle.agents.basic_agent import BasicAgent
+from examples.agents.backtracking_agent import BacktrackingAgent
+from examples.agents.basic_agent import BasicAgent
 
 
 class BacktrackingSystem(AgentABC):

--- a/examples/agents/visual_agent.py
+++ b/examples/agents/visual_agent.py
@@ -5,7 +5,7 @@ from tenacity import retry_if_exception_type, wait_exponential
 
 from fle.agents.llm.parsing import Policy
 from fle.agents.agent_abc import AgentABC
-from fle.agents.basic_agent import FINAL_INSTRUCTION, GENERAL_INSTRUCTIONS
+from examples.agents.basic_agent import FINAL_INSTRUCTION, GENERAL_INSTRUCTIONS
 from fle.agents.formatters import RecursiveReportFormatter
 from fle.agents.models import CompletionResult, Response
 from fle.commons.models.conversation import Conversation

--- a/fle/__init__.py
+++ b/fle/__init__.py
@@ -5,7 +5,7 @@ import warnings
 
 warnings.filterwarnings("ignore", category=SyntaxWarning, module="slpp")
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 
 # Make submodules available
 from fle import agents, env, eval, cluster, commons

--- a/fle/cluster/run-envs.sh
+++ b/fle/cluster/run-envs.sh
@@ -35,10 +35,16 @@ setup_platform() {
 
 # Function to check for docker compose command
 setup_compose_cmd() {
-    if command -v docker &> /dev/null; then
-        COMPOSE_CMD="docker compose"
-    else
+    if ! command -v docker &> /dev/null; then
         echo "Error: Docker not found. Please install Docker."
+        exit 1
+    fi
+    if docker compose version &> /dev/null; then
+        COMPOSE_CMD="docker compose"
+    elif command -v docker-compose &> /dev/null; then
+        COMPOSE_CMD="docker-compose"
+    else
+        echo "Error: Docker Compose not found. Please install Docker Compose."
         exit 1
     fi
 }

--- a/fle/env/protocols/_mcp/__init__.py
+++ b/fle/env/protocols/_mcp/__init__.py
@@ -1,6 +1,8 @@
 """MCP protocol implementation for Factorio Learning Environment."""
 
 # ruff: noqa: E402
+from __future__ import annotations
+
 from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -8,15 +10,29 @@ from dataclasses import dataclass
 try:
     from fastmcp import FastMCP
 
-    # Create the MCP server instance FIRST
-    mcp = FastMCP(
-        "Factorio Learning Environment",
-        dependencies=["dulwich", "numpy", "pillow"],
-    )
     _FASTMCP_AVAILABLE = True
 except ImportError:
-    mcp = None
+    FastMCP = None
     _FASTMCP_AVAILABLE = False
+
+
+@asynccontextmanager
+async def fle_lifespan(server) -> AsyncIterator[FactorioContext]:
+    """Manage the Factorio server lifecycle within the MCP session"""
+    connection_message = await initialize_session()
+    context = FactorioContext(connection_message=connection_message, state=state)
+    try:
+        yield context
+    finally:
+        await shutdown_session()
+
+
+# Create the MCP server instance FIRST; the lifespan must be passed to the
+# constructor (assigning it as an attribute afterwards is ignored by fastmcp).
+if _FASTMCP_AVAILABLE:
+    mcp = FastMCP("Factorio Learning Environment", lifespan=fle_lifespan)
+else:
+    mcp = None
 
 # Now import other modules that use mcp
 if _FASTMCP_AVAILABLE:
@@ -35,21 +51,6 @@ class FactorioContext:
 
     connection_message: str
     state: FactorioMCPState
-
-
-@asynccontextmanager
-async def fle_lifespan(server) -> AsyncIterator[FactorioContext]:
-    """Manage the Factorio server lifecycle within the MCP session"""
-    connection_message = await initialize_session()
-    context = FactorioContext(connection_message=connection_message, state=state)
-    try:
-        yield context
-    finally:
-        await shutdown_session()
-
-
-# Attach the lifespan to mcp
-mcp.lifespan = fle_lifespan
 
 
 # Export mcp for other modules

--- a/fle/run.py
+++ b/fle/run.py
@@ -639,8 +639,11 @@ Examples:
             "text_only",
             "minimal_context",
             "hud",
+            "hud_text_only",
+            "fat_hud",
             "balanced",
             "reasoning_only",
+            "pruned_gamestate",
         ],
         help="Solver variant to use (default depends on task type)",
     )

--- a/fle/run.py
+++ b/fle/run.py
@@ -196,6 +196,9 @@ def fle_inspect_eval(args):
             args.model = "openai/gpt-4o-mini"
         cmd.extend(["--model", args.model])
 
+        if getattr(args, "model_base_url", None):
+            cmd.extend(["--model-base-url", args.model_base_url])
+
         # Add reasoning configuration for reasoning models
         if hasattr(args, "reasoning_effort") and args.reasoning_effort:
             cmd.extend(["--reasoning-effort", args.reasoning_effort])
@@ -621,6 +624,12 @@ Examples:
     )
     parser_inspect.add_argument(
         "--model", help="Model to use for evaluation (e.g., openai/gpt-4o-mini)"
+    )
+    parser_inspect.add_argument(
+        "--model-base-url",
+        help="Base URL for the model API, passed through to inspect eval. "
+        "Use with an openai-api/... model to target local or self-hosted "
+        "OpenAI-compatible endpoints (e.g. vLLM, LM Studio, llama-server)",
     )
     parser_inspect.add_argument(
         "--env-id", help="Specific environment/task to evaluate (default: all tasks)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,8 @@ all = [
     "scikit-image>=0.25.2",
 ]
 mcp = [
-    "mcp[cli]",
+    "mcp[cli]>=1.24.0,<2",
+    "fastmcp>=2.14.0",
     "dulwich",
 ]
 env = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "factorio-learning-environment"
-version = "0.4.5"
+version = "0.4.6"
 description = "Factorio Learning Environment"
 authors = [
     {name = "Jack Hopkins", email = "noreply@github.com"},

--- a/tests/eval/test_solver_choices_sync.py
+++ b/tests/eval/test_solver_choices_sync.py
@@ -1,0 +1,64 @@
+"""Keep the fle inspect-eval --solver CLI choices in sync with SOLVER_MAP.
+
+Parses both files with ast rather than importing them, so the test needs
+neither a running Factorio server nor the eval dependency stack.
+"""
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUN_PY = REPO_ROOT / "fle" / "run.py"
+EVAL_SET_PY = REPO_ROOT / "fle" / "eval" / "inspect" / "integration" / "eval_set.py"
+
+
+def _solver_map_keys() -> set[str]:
+    """Extract the string keys of the SOLVER_MAP dict literal in eval_set.py."""
+    tree = ast.parse(EVAL_SET_PY.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if "SOLVER_MAP" in targets and isinstance(node.value, ast.Dict):
+                return {
+                    key.value
+                    for key in node.value.keys
+                    if isinstance(key, ast.Constant) and isinstance(key.value, str)
+                }
+    raise AssertionError("SOLVER_MAP dict literal not found in eval_set.py")
+
+
+def _cli_solver_choices() -> set[str]:
+    """Extract the choices list of the --solver argument in run.py."""
+    tree = ast.parse(RUN_PY.read_text())
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call)
+            and getattr(node.func, "attr", "") == "add_argument"
+        ):
+            continue
+        args = [a.value for a in node.args if isinstance(a, ast.Constant)]
+        if "--solver" not in args:
+            continue
+        for kw in node.keywords:
+            if kw.arg == "choices" and isinstance(kw.value, ast.List):
+                return {
+                    elt.value
+                    for elt in kw.value.elts
+                    if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                }
+    raise AssertionError(
+        "--solver add_argument with a choices list not found in run.py"
+    )
+
+
+def test_cli_solver_choices_match_solver_map() -> None:
+    solver_map = _solver_map_keys()
+    cli_choices = _cli_solver_choices()
+    missing_from_cli = solver_map - cli_choices
+    unknown_to_solver_map = cli_choices - solver_map
+    assert not missing_from_cli, (
+        f"Solvers defined in SOLVER_MAP but not selectable via --solver: {sorted(missing_from_cli)}"
+    )
+    assert not unknown_to_solver_map, (
+        f"--solver choices with no SOLVER_MAP entry: {sorted(unknown_to_solver_map)}"
+    )

--- a/tests/examples/test_example_agent_imports.py
+++ b/tests/examples/test_example_agent_imports.py
@@ -1,0 +1,22 @@
+"""The shipped example agents must at least be importable.
+
+Regression test for the example modules importing BasicAgent and
+BacktrackingAgent from fle.agents.*, where they do not exist (the
+implementations live in examples/agents/).
+"""
+
+import importlib
+
+import pytest
+
+EXAMPLE_AGENT_MODULES = [
+    "examples.agents.basic_agent",
+    "examples.agents.backtracking_agent",
+    "examples.agents.backtracking_system",
+    "examples.agents.visual_agent",
+]
+
+
+@pytest.mark.parametrize("module_name", EXAMPLE_AGENT_MODULES)
+def test_example_agent_module_imports(module_name: str) -> None:
+    importlib.import_module(module_name)


### PR DESCRIPTION
Staging branch for v0.4.6, squash-merging five verified fixes, plus version bump and changelog.

## Included PRs
- #386 — example agents import from examples.agents (the fle.agents modules they referenced do not exist); adds import tests
- #387 — expose hud_text_only, fat_hud, pruned_gamestate in --solver choices, with a sync test against SOLVER_MAP
- #388 — make the [mcp] extra installable (declares fastmcp) and attach the MCP server lifespan via the FastMCP constructor (the post-hoc assignment was silently ignored)
- #391 — add --model-base-url passthrough to fle inspect-eval (verified against inspect's CLI)
- #365 — cluster script falls back to standalone docker-compose when the docker compose plugin is missing

## Verification
- All five squash-merge cleanly onto v0.4.5 main
- New tests pass on the branch: test_example_agent_imports (4) + test_solver_choices_sync (1)
- fle.run imports clean; --model-base-url appears in fle inspect-eval --help
- ruff check and format pass with CI's version (0.11.13)

Note: squashed source PRs (#386, #387, #388, #391, #365) will not auto-close — close them manually after merging.