### PR TITLE
Release 0.4.7: opt-in env-init retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Factorio Learning Environment will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.7] - 2026-09-04
+
+### Added
+
+- Opt-in retry of transient Factorio env-init failures via `fle inspect-eval --init-retries N` (or `FLE_INIT_RETRIES`). Disabled by default (single attempt, previous behavior). On retry, Lua scripts are force re-uploaded (`cache_scripts=False`) to clear stale server-side state on recycled containers; configuration errors are never retried (#367)
+
 ## [0.4.6] - 2026-09-03
 
 ### Fixed

--- a/fle/__init__.py
+++ b/fle/__init__.py
@@ -5,7 +5,7 @@ import warnings
 
 warnings.filterwarnings("ignore", category=SyntaxWarning, module="slpp")
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 
 # Make submodules available
 from fle import agents, env, eval, cluster, commons

--- a/fle/env/gym_env/registry.py
+++ b/fle/env/gym_env/registry.py
@@ -99,8 +99,9 @@ def make_factorio_env(spec: GymEnvironmentSpec, run_idx: int) -> FactorioGymEnv:
     """Factory function to create a Factorio gym environment.
 
     The instance-creation block (FactorioInstance build + task.setup +
-    FactorioGymEnv wrap) is retried up to ``FLE_INIT_RETRIES`` times
-    (default 3) with backoff. Transient failures like
+    FactorioGymEnv wrap) can be retried with backoff by setting
+    ``FLE_INIT_RETRIES`` > 1 (default 1, i.e. retries disabled; enable
+    via ``fle inspect-eval --init-retries N``). Transient failures like
     ``"Could not save research state"`` happen when a Factorio container
     is recycled across samples and its RCON server returns malformed
     data on the first reset; a short wait + fresh attempt clears it.
@@ -159,7 +160,9 @@ def make_factorio_env(spec: GymEnvironmentSpec, run_idx: int) -> FactorioGymEnv:
     # ``cache_scripts=False`` so all scripts are freshly re-uploaded
     # (re-initializing their global Lua state). Plus longer backoff
     # so containers have time to settle.
-    max_attempts = int(os.getenv("FLE_INIT_RETRIES", "5"))
+    # Retries are opt-in: default is a single attempt (previous behavior).
+    # Enable with `fle inspect-eval --init-retries N` or FLE_INIT_RETRIES=N.
+    max_attempts = max(1, int(os.getenv("FLE_INIT_RETRIES", "1")))
     backoff = [int(x) for x in os.getenv("FLE_INIT_BACKOFF", "2,5,10,20,30").split(",")]
     last_err: Optional[Exception] = None
     for attempt in range(1, max_attempts + 1):

--- a/fle/env/gym_env/registry.py
+++ b/fle/env/gym_env/registry.py
@@ -1,4 +1,5 @@
 import os
+import time
 from dataclasses import dataclass, asdict
 from typing import Any, Dict, List, Optional
 
@@ -95,66 +96,116 @@ _registry = FactorioGymRegistry()
 
 
 def make_factorio_env(spec: GymEnvironmentSpec, run_idx: int) -> FactorioGymEnv:
-    """Factory function to create a Factorio gym environment"""
+    """Factory function to create a Factorio gym environment.
+
+    The instance-creation block (FactorioInstance build + task.setup +
+    FactorioGymEnv wrap) is retried up to ``FLE_INIT_RETRIES`` times
+    (default 3) with backoff. Transient failures like
+    ``"Could not save research state"`` happen when a Factorio container
+    is recycled across samples and its RCON server returns malformed
+    data on the first reset; a short wait + fresh attempt clears it.
+
+    Configuration errors (no containers available, invalid run_idx) are
+    raised without retry — they won't fix themselves.
+    """
     # Create task from the task definition
     task = TaskFactory.create_task(spec.task_config_path)
 
-    # Create Factorio instance
-    try:
-        # Check for external server configuration via environment variables
-        address = os.getenv("FACTORIO_SERVER_ADDRESS")
-        tcp_port = os.getenv("FACTORIO_SERVER_PORT")
+    # Resolve server address (no retry — pure config)
+    address = os.getenv("FACTORIO_SERVER_ADDRESS")
+    tcp_port = os.getenv("FACTORIO_SERVER_PORT")
 
-        if not address and not tcp_port:
-            try:
-                ips, udp_ports, tcp_ports = get_local_container_ips()
-            except ValueError:
-                raise RuntimeError("No Factorio containers available")
+    if not address and not tcp_port:
+        try:
+            ips, udp_ports, tcp_ports = get_local_container_ips()
+        except ValueError:
+            raise RuntimeError("No Factorio containers available")
 
-            if len(tcp_ports) == 0:
-                raise RuntimeError("No Factorio containers available")
+        if len(tcp_ports) == 0:
+            raise RuntimeError("No Factorio containers available")
 
-            # Apply port offset for multiple terminal sessions
-            container_idx = PORT_OFFSET + run_idx
-            if container_idx >= len(tcp_ports):
-                raise RuntimeError(
-                    f"Container index {container_idx} (PORT_OFFSET={PORT_OFFSET} + run_idx={run_idx}) exceeds available containers ({len(tcp_ports)})"
-                )
+        # Apply port offset for multiple terminal sessions
+        container_idx = PORT_OFFSET + run_idx
+        if container_idx >= len(tcp_ports):
+            raise RuntimeError(
+                f"Container index {container_idx} (PORT_OFFSET={PORT_OFFSET} + run_idx={run_idx}) exceeds available containers ({len(tcp_ports)})"
+            )
 
-            address = ips[container_idx]
-            tcp_port = tcp_ports[container_idx]
+        address = ips[container_idx]
+        tcp_port = tcp_ports[container_idx]
 
-        common_kwargs = {
-            "address": address,
-            "tcp_port": int(tcp_port),
-            "num_agents": spec.num_agents,
-            "fast": True,
-            "cache_scripts": True,
-            "inventory": {},
-            "all_technologies_researched": False,
-        }
+    common_kwargs = {
+        "address": address,
+        "tcp_port": int(tcp_port),
+        "num_agents": spec.num_agents,
+        "fast": True,
+        "cache_scripts": True,
+        "inventory": {},
+        "all_technologies_researched": False,
+    }
 
-        print(f"Using local Factorio container at {address}:{tcp_port}")
-        if spec.num_agents > 1:
-            instance = run_async_safely(A2AFactorioInstance.create(**common_kwargs))
-        else:
-            instance = FactorioInstance(**common_kwargs)
+    print(f"Using local Factorio container at {address}:{tcp_port}")
 
-        # Set initial speed and unpause
-        instance.set_speed_and_unpause(10)
+    # Retry the FactorioInstance build + task.setup block. The "Could
+    # not save research state" failure mode happens when a Factorio
+    # container is recycled across samples and its Lua script registry
+    # holds stale state from the previous instance. ``FactorioInstance``
+    # with ``cache_scripts=True`` (the default) compares checksums and
+    # skips re-uploading scripts that already match — but the Lua VM
+    # state behind those scripts can be corrupt. ``cleanup()`` only
+    # closes the RCON connection, it does not reset the server.
+    #
+    # Fix: on every retry attempt after the first, force
+    # ``cache_scripts=False`` so all scripts are freshly re-uploaded
+    # (re-initializing their global Lua state). Plus longer backoff
+    # so containers have time to settle.
+    max_attempts = int(os.getenv("FLE_INIT_RETRIES", "5"))
+    backoff = [int(x) for x in os.getenv("FLE_INIT_BACKOFF", "2,5,10,20,30").split(",")]
+    last_err: Optional[Exception] = None
+    for attempt in range(1, max_attempts + 1):
+        instance = None
+        try:
+            attempt_kwargs = dict(common_kwargs)
+            if attempt > 1:
+                # Force fresh Lua script upload on retry — clears stale
+                # server-side state that survived ``cleanup()``.
+                attempt_kwargs["cache_scripts"] = False
 
-        # Setup the task
-        task.setup(instance)
+            if spec.num_agents > 1:
+                instance = run_async_safely(A2AFactorioInstance.create(**attempt_kwargs))
+            else:
+                instance = FactorioInstance(**attempt_kwargs)
 
-        # Create and return the gym environment
-        env = FactorioGymEnv(
-            instance=instance, task=task, enable_vision=spec.enable_vision
-        )
+            # Set initial speed and unpause
+            instance.set_speed_and_unpause(10)
 
-        return env
+            # Setup the task
+            task.setup(instance)
 
-    except Exception as e:
-        raise RuntimeError(f"Failed to create Factorio environment: {e}")
+            # Create and return the gym environment
+            return FactorioGymEnv(
+                instance=instance, task=task, enable_vision=spec.enable_vision
+            )
+
+        except Exception as e:
+            last_err = e
+            print(
+                f"[make_factorio_env] attempt {attempt}/{max_attempts} failed "
+                f"on container {address}:{tcp_port} "
+                f"(cache_scripts={attempt_kwargs.get('cache_scripts')}): {e!r}"
+            )
+            # Best-effort cleanup of partially-built instance.
+            if instance is not None:
+                try:
+                    instance.cleanup()
+                except Exception:  # noqa: BLE001
+                    pass
+            if attempt < max_attempts:
+                wait = backoff[min(attempt - 1, len(backoff) - 1)]
+                print(f"[make_factorio_env] sleeping {wait}s before retry")
+                time.sleep(wait)
+
+    raise RuntimeError(f"Failed to create Factorio environment: {last_err}")
 
 
 def register_all_environments() -> None:

--- a/fle/env/gym_env/registry.py
+++ b/fle/env/gym_env/registry.py
@@ -175,7 +175,9 @@ def make_factorio_env(spec: GymEnvironmentSpec, run_idx: int) -> FactorioGymEnv:
                 attempt_kwargs["cache_scripts"] = False
 
             if spec.num_agents > 1:
-                instance = run_async_safely(A2AFactorioInstance.create(**attempt_kwargs))
+                instance = run_async_safely(
+                    A2AFactorioInstance.create(**attempt_kwargs)
+                )
             else:
                 instance = FactorioInstance(**attempt_kwargs)
 

--- a/fle/run.py
+++ b/fle/run.py
@@ -254,6 +254,11 @@ def fle_inspect_eval(args):
             os.environ["FLE_VISION"] = "true"
             print("Vision mode enabled")
 
+        # Opt-in retry of transient env-init failures (recycled containers)
+        if hasattr(args, "init_retries") and args.init_retries:
+            os.environ["FLE_INIT_RETRIES"] = str(args.init_retries)
+            print(f"Init retries enabled: up to {args.init_retries} attempts")
+
         # Set scenario for sandbox containers
         if hasattr(args, "scenario") and args.scenario:
             os.environ["FLE_SCENARIO"] = args.scenario
@@ -633,6 +638,13 @@ Examples:
     )
     parser_inspect.add_argument(
         "--env-id", help="Specific environment/task to evaluate (default: all tasks)"
+    )
+    parser_inspect.add_argument(
+        "--init-retries",
+        type=int,
+        help="Retry transient Factorio env-init failures up to N attempts with "
+        "backoff (default: 1, no retry). Helps when reused containers fail "
+        "their first reset, e.g. 'Could not save research state'",
     )
     parser_inspect.add_argument(
         "--tasks",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "factorio-learning-environment"
-version = "0.4.6"
+version = "0.4.7"
 description = "Factorio Learning Environment"
 authors = [
     {name = "Jack Hopkins", email = "noreply@github.com"},


### PR DESCRIPTION
Staging branch for v0.4.7: #367 squash-merged and gated behind an opt-in flag, plus version bump and changelog.

## Included
- #367 — retry transient Factorio env-init failures in make_factorio_env (rasdani), with a follow-up commit gating it off by default:
  - Default is a single attempt — identical to previous behavior
  - Enable with `fle inspect-eval --init-retries N` (sets FLE_INIT_RETRIES for the eval subprocess), or FLE_INIT_RETRIES/FLE_INIT_BACKOFF directly
  - On retry, Lua scripts are force re-uploaded (cache_scripts=False) to clear stale server state on recycled containers
  - Configuration errors (no containers, bad run_idx) are never retried

## Verification
- Merges conflict-free onto v0.4.6 main; registry imports clean
- Verified default-off (1 attempt), opt-in via env var, and clamp of values < 1
- --init-retries appears in fle inspect-eval --help and pipes through os.environ to the inspect subprocess
- ruff check and format pass with CI's version (0.11.13)

Note: squashed source PR #367 will not auto-close — close it manually after merging.