### PR TITLE
Release 0.4.8: linear-time state save/restore and tool responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Factorio Learning Environment will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.8] - 2026-09-04
+
+### Fixed
+
+- Tool responses are compressed in Lua (`helpers.encode_string`, zlib+base64) before RCON transfer and decoded in Python ahead of the existing parser. Factorio's RCON stalls ~40 ms per 4 KB response fragment, so large responses were dominated by transfer: saving a 1,600-entity factory took 10.5 s (~97% transfer) and scaled quadratically. Now linear: 0.52 s at 1,600 entities, 3.7 s at 10,000. `get_entities()` on large factories gets the same fix (7.9 s → 0.77 s at 1,600 entities)
+- `dump()` in `mods/utils.lua` builds its output via `table.concat` instead of O(N²) repeated string concatenation; output is byte-identical
+- Removed duplicate global `dump()` definitions from the `score` tools that clobbered the shared implementation
+
 ## [0.4.7] - 2026-09-04
 
 ### Added

--- a/fle/__init__.py
+++ b/fle/__init__.py
@@ -5,7 +5,7 @@ import warnings
 
 warnings.filterwarnings("ignore", category=SyntaxWarning, module="slpp")
 
-__version__ = "0.4.7"
+__version__ = "0.4.8"
 
 # Make submodules available
 from fle import agents, env, eval, cluster, commons

--- a/fle/env/mods/utils.lua
+++ b/fle/env/mods/utils.lua
@@ -191,17 +191,28 @@ storage.utils.ensure_valid_character = function(player_index)
     return char
 end
 
+-- Serializes a value to the same format the Python client parses.
+-- Accumulates parts in a table and concatenates once: repeated `s = s .. x`
+-- reallocates the whole string per append, which made serializing large
+-- tool responses (e.g. save_entity_state on big factories) O(N^2).
 function dump(o)
-   if type(o) == 'table' then
-      local s = '{ '
-      for k,v in pairs(o) do
-         if type(k) ~= 'number' then k = '"'..k..'"' end
-         s = s .. '['..k..'] = ' .. dump(v) .. ','
+   local parts = {}
+   local function walk(v)
+      if type(v) == 'table' then
+         parts[#parts + 1] = '{ '
+         for k, item in pairs(v) do
+            if type(k) ~= 'number' then k = '"'..k..'"' end
+            parts[#parts + 1] = '['..k..'] = '
+            walk(item)
+            parts[#parts + 1] = ','
+         end
+         parts[#parts + 1] = '} '
+      else
+         parts[#parts + 1] = tostring(v)
       end
-      return s .. '} '
-   else
-      return tostring(o)
    end
+   walk(o)
+   return table.concat(parts)
 end
 
 function storage.utils.inspect(player, radius, position)

--- a/fle/env/tools/admin/score/server.lua
+++ b/fle/env/tools/admin/score/server.lua
@@ -330,18 +330,7 @@ production_score.get_production_scores = function(_price_list)
   return scores
 end
 
-function dump(o)
-  if type(o) == 'table' then
-     local s = '{ '
-     for k,v in pairs(o) do
-        if type(k) ~= 'number' then k = '"'..k..'"' end
-        s = s .. '['..k..'] = ' .. dump(v) .. ','
-     end
-     return s .. '} '
-  else
-     return tostring(o)
-  end
-end
+-- dump() is provided globally by mods/utils.lua; do not redefine it here.
 
 storage.goal = nil
 

--- a/fle/env/tools/agent/score/server.lua
+++ b/fle/env/tools/agent/score/server.lua
@@ -330,18 +330,7 @@ production_score.get_production_scores = function(_price_list)
   return scores
 end
 
-function dump(o)
-  if type(o) == 'table' then
-     local s = '{ '
-     for k,v in pairs(o) do
-        if type(k) ~= 'number' then k = '"'..k..'"' end
-        s = s .. '['..k..'] = ' .. dump(v) .. ','
-     end
-     return s .. '} '
-  else
-     return tostring(o)
-  end
-end
+-- dump() is provided globally by mods/utils.lua; do not redefine it here.
 
 -- Calculate the total value of harvested items (raw resources gathered manually or by drills)
 local function get_harvested_value(price_list)

--- a/fle/env/tools/controller.py
+++ b/fle/env/tools/controller.py
@@ -20,25 +20,35 @@ from fle.env.utils.rcon import _lua2python
 COMMAND = "/silent-command"
 
 # Tool responses are zlib+base64 compressed in Lua (helpers.encode_string)
-# before rcon.print. Factorio's RCON stalls ~40ms per 4KB fragment on large
-# responses (Nagle/delayed-ACK), so a 1MB payload takes ~10s uncompressed
-# but a few ms compressed. The Lua side falls back to the raw dump if
-# encode_string fails, so decoding falls back to the raw response too.
+# before rcon.print, marked with an explicit sentinel prefix. Factorio's RCON
+# stalls ~40ms per 4KB fragment on large responses (Nagle/delayed-ACK), so a
+# 1MB payload takes ~10s uncompressed but a few ms compressed. The sentinel
+# makes decoding deterministic: only lines the wrapper actually encoded are
+# decoded, and anything else (Lua fallback, engine messages, debug prints
+# from tool scripts) passes through untouched.
+_SENTINEL = "FLEZ1:"
 _RESPONSE_WRAPPER = (
-    "local _d = dump({a=a, b=b}); rcon.print(helpers.encode_string(_d) or _d)"
+    "local _d = dump({a=a, b=b}); local _e = helpers.encode_string(_d); "
+    f"if _e then rcon.print('{_SENTINEL}' .. _e) else rcon.print(_d) end"
 )
 
 
 def _decode_response(response: str) -> str:
-    """Decode a compressed tool response; pass through anything else."""
-    if not response:
+    """Decode sentinel-marked compressed lines; pass everything else through."""
+    if not response or _SENTINEL not in response:
         return response
-    try:
-        return zlib.decompress(base64.b64decode(response, validate=True)).decode(
-            "utf-8"
-        )
-    except Exception:
-        return response
+    decoded_lines = []
+    for line in response.split("\n"):
+        if line.strip().startswith(_SENTINEL):
+            blob = line.strip()[len(_SENTINEL) :]
+            try:
+                line = zlib.decompress(base64.b64decode(blob, validate=True)).decode(
+                    "utf-8"
+                )
+            except Exception:
+                line = blob
+        decoded_lines.append(line)
+    return "\n".join(decoded_lines)
 
 
 # Maximum retries for RCON [processing] errors

--- a/fle/env/tools/controller.py
+++ b/fle/env/tools/controller.py
@@ -1,5 +1,7 @@
+import base64
 import json
 import time
+import zlib
 from timeit import default_timer as timer
 from typing import List, Tuple, Dict, Any
 
@@ -16,6 +18,25 @@ from fle.env.namespace import FactorioNamespace
 from fle.env.utils.rcon import _lua2python
 
 COMMAND = "/silent-command"
+
+# Tool responses are zlib+base64 compressed in Lua (helpers.encode_string)
+# before rcon.print. Factorio's RCON stalls ~40ms per 4KB fragment on large
+# responses (Nagle/delayed-ACK), so a 1MB payload takes ~10s uncompressed
+# but a few ms compressed. The Lua side falls back to the raw dump if
+# encode_string fails, so decoding falls back to the raw response too.
+_RESPONSE_WRAPPER = "local _d = dump({a=a, b=b}); rcon.print(helpers.encode_string(_d) or _d)"
+
+
+def _decode_response(response: str) -> str:
+    """Decode a compressed tool response; pass through anything else."""
+    if not response:
+        return response
+    try:
+        return zlib.decompress(base64.b64decode(response, validate=True)).decode(
+            "utf-8"
+        )
+    except Exception:
+        return response
 
 # Maximum retries for RCON [processing] errors
 MAX_PROCESSING_RETRIES = 3
@@ -175,8 +196,10 @@ class Controller:
         start = time.time()
         parameters = [lua.encode(arg) for arg in args]
         invocation = f"pcall(storage.actions.{self.name}{(', ' if parameters else '') + ','.join(parameters)})"
-        wrapped = f"{COMMAND} a, b = {invocation}; rcon.print(dump({{a=a, b=b}}))"
-        lua_response = self.connection.rcon_client.send_command(wrapped)
+        wrapped = f"{COMMAND} a, b = {invocation}; {_RESPONSE_WRAPPER}"
+        lua_response = _decode_response(
+            self.connection.rcon_client.send_command(wrapped)
+        )
 
         # Check for [processing] error from RCON layer
         if self._check_for_processing_error(lua_response):
@@ -262,8 +285,10 @@ class Controller:
             start = time.time()
             parameters = [lua.encode(arg) for arg in args]
             invocation = f"pcall(storage.actions.{self.name}{(', ' if parameters else '') + ','.join(parameters)})"
-            wrapped = f"{COMMAND} a, b = {invocation}; rcon.print(dump({{a=a, b=b}}))"
-            lua_response = self.connection.rcon_client.send_command(wrapped)
+            wrapped = f"{COMMAND} a, b = {invocation}; {_RESPONSE_WRAPPER}"
+            lua_response = _decode_response(
+                self.connection.rcon_client.send_command(wrapped)
+            )
             parsed, elapsed = _lua2python(invocation, lua_response, start=start)
             if not parsed["a"] and "b" in parsed and isinstance(parsed["b"], str):
                 parts = lua_response.split('["b"] = ')

--- a/fle/env/tools/controller.py
+++ b/fle/env/tools/controller.py
@@ -24,7 +24,9 @@ COMMAND = "/silent-command"
 # responses (Nagle/delayed-ACK), so a 1MB payload takes ~10s uncompressed
 # but a few ms compressed. The Lua side falls back to the raw dump if
 # encode_string fails, so decoding falls back to the raw response too.
-_RESPONSE_WRAPPER = "local _d = dump({a=a, b=b}); rcon.print(helpers.encode_string(_d) or _d)"
+_RESPONSE_WRAPPER = (
+    "local _d = dump({a=a, b=b}); rcon.print(helpers.encode_string(_d) or _d)"
+)
 
 
 def _decode_response(response: str) -> str:
@@ -37,6 +39,7 @@ def _decode_response(response: str) -> str:
         )
     except Exception:
         return response
+
 
 # Maximum retries for RCON [processing] errors
 MAX_PROCESSING_RETRIES = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "factorio-learning-environment"
-version = "0.4.7"
+version = "0.4.8"
 description = "Factorio Learning Environment"
 authors = [
     {name = "Jack Hopkins", email = "noreply@github.com"},


### PR DESCRIPTION
Staging branch for v0.4.8: RCON response performance fixes, plus version bump and changelog.

## The problem
Factorio's RCON stalls ~40 ms per 4 KB response fragment (Nagle/delayed-ACK), so large tool responses were dominated by pure transfer — confirmed content-independent (1 MB of string.rep junk: 9.7 s; same 1 MB compressed in Lua: 17 ms). Saving a 1,600-entity factory took 10.5 s (~97% transfer) and scaled quadratically; 10k entities extrapolates to ~5–6 minutes.

## The fix (3 commits)
- Compress every tool response in Lua (helpers.encode_string, zlib+base64) before rcon.print; decode in Python ahead of the existing parser. Parsed bytes unchanged; both sides fall back to the raw string.
- Linearize dump() with table.concat (was O(N²) string concatenation); output verified byte-identical in-game.
- Remove duplicate global dump() definitions in the score tools that clobbered the shared one.

## Measured results (10 trials/size, live server)
| Entities | Save before | Save after | Restore after |
|---|---|---|---|
| 1,600 | 10.54 s | 0.52 s | 0.39 s |
| 10,000 | ~5–6 min (extrapolated) | 3.68 s | 3.68 s |

get_entities() at 1,600 entities: 7.86 s → 0.77 s. Both paths now scale linearly (2.0× per doubling through 10k); round-trip entity counts verified at every size.

## Verification
- Full test suite (actions, connect, eval, gym_env, unit, examples): 401 passed, failure set byte-identical to the pre-fix baseline
- ruff check and format pass with CI's version (0.11.13)