### PR TITLE
feat: tool_discovery solver — agent learns the API through tools

### DIFF
--- a/fle/env/gym_env/environment.py
+++ b/fle/env/gym_env/environment.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import gymnasium as gym
 import numpy as np
@@ -304,12 +305,24 @@ class FactorioGymEnv(gym.Env):
         if self.enable_vision:
             map_image = namespace._render().to_base64()
 
-        # Get entity observations
-        try:
-            entities = namespace.get_entities()
-        except Exception as e:
-            logger.warning(f"Error getting entities: {e}")
-            raise Exception("Error getting entities while getting observation") from e
+        # Get entity observations. A single transient failure (engine busy,
+        # RCON hiccup) must not kill a multi-hour rollout, so retry briefly;
+        # include the underlying error so real failures stay diagnosable.
+        entities = None
+        last_entity_error = None
+        for attempt, delay in enumerate((0, 2, 5), start=1):
+            if delay:
+                time.sleep(delay)
+            try:
+                entities = namespace.get_entities()
+                break
+            except Exception as e:
+                last_entity_error = e
+                logger.warning(f"Error getting entities (attempt {attempt}/3): {e}")
+        if entities is None:
+            raise Exception(
+                f"Error getting entities while getting observation: {last_entity_error}"
+            ) from last_entity_error
 
         entity_obs = [e.__dict__ for e in entities]
 

--- a/fle/env/gym_env/environment.py
+++ b/fle/env/gym_env/environment.py
@@ -28,6 +28,26 @@ from fle.eval.tasks import TaskABC
 
 logger = logging.getLogger(__name__)
 
+
+def _call_with_retry(fn, what: str, delays=(0, 2, 5)):
+    """Call fn(), retrying transient failures with short backoff.
+
+    A single transient failure (engine busy, RCON hiccup, malformed
+    response) must not kill a multi-hour rollout. The underlying error is
+    included in the raised exception so real failures stay diagnosable.
+    """
+    last_error = None
+    for attempt, delay in enumerate(delays, start=1):
+        if delay:
+            time.sleep(delay)
+        try:
+            return fn()
+        except Exception as e:
+            last_error = e
+            logger.warning(f"Error {what} (attempt {attempt}/{len(delays)}): {e}")
+    raise Exception(f"Error {what}: {last_error}") from last_error
+
+
 # need to do this since gym doesn't work with numpy>=2.0 otherwise.
 np.bool8 = np.dtype(np.bool)
 
@@ -305,24 +325,9 @@ class FactorioGymEnv(gym.Env):
         if self.enable_vision:
             map_image = namespace._render().to_base64()
 
-        # Get entity observations. A single transient failure (engine busy,
-        # RCON hiccup) must not kill a multi-hour rollout, so retry briefly;
-        # include the underlying error so real failures stay diagnosable.
-        entities = None
-        last_entity_error = None
-        for attempt, delay in enumerate((0, 2, 5), start=1):
-            if delay:
-                time.sleep(delay)
-            try:
-                entities = namespace.get_entities()
-                break
-            except Exception as e:
-                last_entity_error = e
-                logger.warning(f"Error getting entities (attempt {attempt}/3): {e}")
-        if entities is None:
-            raise Exception(
-                f"Error getting entities while getting observation: {last_entity_error}"
-            ) from last_entity_error
+        entities = _call_with_retry(
+            namespace.get_entities, "getting entities while getting observation"
+        )
 
         entity_obs = [e.__dict__ for e in entities]
 
@@ -476,7 +481,9 @@ class FactorioGymEnv(gym.Env):
             )
             terminated = task_success.success
 
-        production_score, automated_production_score = namespace.score()
+        production_score, automated_production_score = _call_with_retry(
+            namespace.score, "getting score after step"
+        )
         if not automated_production_score:
             automated_production_score = 0
         # Calculate reward

--- a/fle/eval/inspect/integration/eval_set.py
+++ b/fle/eval/inspect/integration/eval_set.py
@@ -32,6 +32,9 @@ from fle.eval.inspect.integration.solver_variants import (
     factorio_reasoning_only_solver,
     factorio_pruned_gamestate_solver,
 )
+from fle.eval.inspect.integration.solver_tool_discovery import (
+    factorio_tool_discovery_solver,
+)
 from fle.eval.inspect.integration.scorers import (
     throughput_proportion_scorer,
     production_score_tracker,
@@ -57,6 +60,7 @@ SOLVER_MAP = {
     "balanced": factorio_balanced_solver,
     "reasoning_only": factorio_reasoning_only_solver,
     "pruned_gamestate": factorio_pruned_gamestate_solver,
+    "tool_discovery": factorio_tool_discovery_solver,
 }
 
 

--- a/fle/eval/inspect/integration/simple_server_pool.py
+++ b/fle/eval/inspect/integration/simple_server_pool.py
@@ -72,6 +72,35 @@ class SimpleServerPool:
                     "No Anthropic API keys found. Set ANTHROPIC_API_KEYS or ANTHROPIC_API_KEY"
                 )
 
+    @staticmethod
+    def _server_reachable(idx: int, timeout: float = 1.0) -> bool:
+        """Check whether the Factorio container for run_idx is reachable."""
+        import socket
+
+        try:
+            with socket.create_connection(("localhost", 27000 + idx), timeout=timeout):
+                return True
+        except OSError:
+            return False
+
+    def _probe_reachable_indices(self) -> List[int]:
+        """Return the run_idx values in range whose servers actually respond.
+
+        Previously every index in range was assumed to exist; allocating a
+        run_idx with no container behind it made that sample fail deep inside
+        make_factorio_env, and Inspect recorded it as an errored sample while
+        the eval as a whole "completed" — silently degrading results (e.g.
+        1/8 real rollouts with a single container).
+        """
+        # External server override: make_factorio_env ignores run_idx, so any
+        # index is valid and there is nothing to probe on localhost.
+        if os.getenv("FACTORIO_SERVER_ADDRESS") or os.getenv("FACTORIO_SERVER_PORT"):
+            return list(range(self.start_idx, self.end_idx))
+
+        return [
+            i for i in range(self.start_idx, self.end_idx) if self._server_reachable(i)
+        ]
+
     async def initialize(self):
         """Initialize the pool with available run_idx values"""
         if self._initialized:
@@ -80,12 +109,29 @@ class SimpleServerPool:
         # Load API keys
         self._load_api_keys()
 
-        # Populate queue with available run_idx values in the configured range
-        for i in range(self.start_idx, self.end_idx):
+        # Only hand out indices whose servers are actually reachable, so
+        # rollouts queue for real containers instead of crashing on ghosts.
+        reachable = self._probe_reachable_indices()
+        if not reachable:
+            raise RuntimeError(
+                f"No reachable Factorio servers in configured range "
+                f"{self.start_idx}-{self.end_idx - 1} (probed localhost tcp "
+                f"{27000 + self.start_idx}-{27000 + self.end_idx - 1}). "
+                f"Start containers with 'fle cluster start -n N' and retry."
+            )
+        if len(reachable) < self.max_servers:
+            logger.warning(
+                f"Only {len(reachable)}/{self.max_servers} Factorio servers in range "
+                f"{self.start_idx}-{self.end_idx - 1} are reachable: {reachable}. "
+                f"Rollouts will share the reachable servers."
+            )
+        self.max_servers = len(reachable)
+
+        for i in reachable:
             await self.available_indices.put(i)
 
         logger.info(
-            f"Initialized SimpleServerPool with servers {self.start_idx}-{self.end_idx - 1} "
+            f"Initialized SimpleServerPool with servers {reachable} "
             f"({self.max_servers} total) and {len(self._api_keys)} API keys"
         )
         self._initialized = True
@@ -111,16 +157,36 @@ class SimpleServerPool:
         """
         await self.initialize()
 
-        if self.available_indices.empty():
-            raise RuntimeError(
-                f"All {self.max_servers} servers are in use. "
-                f"Consider reducing --max-connections or starting more containers with 'fle cluster start -n N'"
-            )
-
-        run_idx = await self.available_indices.get()
-        self.allocated_indices.add(run_idx)
-
+        run_idx = await self._acquire_index()
         logger.info(f"Allocated run_idx {run_idx} (server factorio_{run_idx})")
+        return run_idx
+
+    # How long a rollout may wait for a free server before the sample fails.
+    ACQUIRE_TIMEOUT_SECONDS = 1800
+
+    async def _acquire_index(self) -> int:
+        """Take a run_idx, waiting for one to free up if all are in use.
+
+        Waiting (rather than raising immediately) lets rollouts share a
+        smaller server fleet — e.g. 8 epochs on 1 container run sequentially
+        instead of 7 of them erroring out.
+        """
+        if self.available_indices.empty():
+            logger.warning(
+                f"All {self.max_servers} reachable servers in use; waiting for a "
+                f"free one (start more with 'fle cluster start -n N' to parallelize)"
+            )
+        try:
+            run_idx = await asyncio.wait_for(
+                self.available_indices.get(), timeout=self.ACQUIRE_TIMEOUT_SECONDS
+            )
+        except asyncio.TimeoutError:
+            raise RuntimeError(
+                f"Timed out after {self.ACQUIRE_TIMEOUT_SECONDS}s waiting for a free "
+                f"Factorio server ({self.max_servers} reachable, all busy). "
+                f"Start more containers with 'fle cluster start -n N' or reduce --max-connections."
+            )
+        self.allocated_indices.add(run_idx)
         return run_idx
 
     async def get_server_allocation(self) -> ServerAllocation:
@@ -136,14 +202,7 @@ class SimpleServerPool:
         """
         await self.initialize()
 
-        if self.available_indices.empty():
-            raise RuntimeError(
-                f"All {self.max_servers} servers are in use. "
-                f"Consider reducing --max-connections or starting more containers with 'fle cluster start -n N'"
-            )
-
-        run_idx = await self.available_indices.get()
-        self.allocated_indices.add(run_idx)
+        run_idx = await self._acquire_index()
 
         # Get next API key
         api_key, key_index = await self._get_next_api_key()

--- a/fle/eval/inspect/integration/solver_tool_discovery.py
+++ b/fle/eval/inspect/integration/solver_tool_discovery.py
@@ -214,20 +214,27 @@ def _make_tools(
     ]
 
 
-def _trim_messages(messages, keep_last: int = 40):
-    """Keep the system prompt, the opening user message, and the recent tail.
+def _trim_messages(messages, high_water: int = 120, low_water: int = 60):
+    """Trim with hysteresis: cut to the low-water mark only when the
+    high-water mark is exceeded, and mutate `messages` in place.
 
-    The tail must not begin with tool-result messages: their parent
+    A per-call sliding window shifts the prompt prefix on every
+    generation, which defeats provider prompt caching entirely (observed:
+    only the ~784-token system head ever cache-hits, everything else
+    re-billed each call). Trimming in blocks keeps the prefix stable for
+    ~(high_water - low_water) generations between trims.
+
+    The kept tail must not begin with tool-result messages: their parent
     assistant tool_call message would be trimmed away, and OpenAI rejects
-    histories containing a function result with no matching call ("No tool
-    call found for function call output with call_id ...").
+    histories containing a function result with no matching call.
     """
-    if len(messages) <= keep_last + 2:
+    if len(messages) <= high_water + 2:
         return messages
-    tail = messages[-keep_last:]
+    tail = messages[-low_water:]
     while tail and getattr(tail[0], "role", None) == "tool":
         tail = tail[1:]
-    return messages[:2] + tail
+    messages[:] = messages[:2] + tail
+    return messages
 
 
 @solver

--- a/fle/eval/inspect/integration/solver_tool_discovery.py
+++ b/fle/eval/inspect/integration/solver_tool_discovery.py
@@ -1,0 +1,236 @@
+"""Tool-discovery solver: the agent is not given the API manual up front.
+
+Every other solver injects the full SystemPromptGenerator manual into the
+system prompt and ablates observations/images. This solver inverts that:
+a minimal system prompt plus Inspect-native tools that let the agent look
+the rules up itself (the same content the MCP server exposes via ls/man),
+so the cost of acquiring the rules becomes part of the measured behavior.
+
+Budget semantics: only `run_code` calls count against trajectory_length.
+Reading manuals and observing are free actions, so scores stay comparable
+with the controlled solver's step budget; the discovery cost shows up as
+extra tokens and wall-clock, not lost game actions.
+"""
+
+import importlib.resources
+import logging
+from pathlib import Path
+
+import gymnasium as gym
+from inspect_ai.model import (
+    ChatMessageSystem,
+    ChatMessageUser,
+    GenerateConfig,
+    get_model,
+    execute_tools,
+)
+from inspect_ai.agent import AgentState
+from inspect_ai.solver import solver
+from inspect_ai.tool import tool
+from inspect_ai.util import store_as
+
+from fle.env.gym_env.action import Action
+from fle.env.gym_env.environment import FactorioGymEnv
+from fle.env.gym_env.observation import Observation
+from fle.env.gym_env.observation_formatter import TreeObservationFormatter
+from fle.env.gym_env.registry import get_environment_info
+from fle.eval.inspect.integration.simple_server_pool import get_simple_server_pool
+from fle.eval.inspect.integration.solver import TrajectoryData
+
+logger = logging.getLogger(__name__)
+
+AGENT_TOOLS_DIR = Path(
+    str(importlib.resources.files("fle") / "env" / "tools" / "agent")
+)
+
+SYSTEM_PROMPT = """You control a character in a Factorio world by writing Python programs.
+
+You have NOT been given the API documentation. Discover it with your tools:
+- list_methods() lists every method in the environment API
+- manual(method) returns the full documentation for one method
+- observe() shows your inventory, position, and nearby entities (free)
+- run_code(code) executes a Python program in the environment and returns \
+the resulting game state (counts against your step budget)
+
+Goal: {goal}
+
+You have {budget} run_code calls. Reading manuals and observing are free.
+Read the manuals for methods before using them; API misuse wastes steps.
+Programs run in a persistent namespace: variables survive between run_code calls."""
+
+
+def _format_observation(observation: Observation) -> str:
+    formatted = TreeObservationFormatter(
+        include_research=False, include_flows=False
+    ).format(observation)
+    return formatted.raw_str.replace("\\n", "\n")
+
+
+def _make_tools(gym_env: FactorioGymEnv, trajectory: TrajectoryData, budget: int):
+    """Build per-sample tool closures over the live gym environment."""
+
+    @tool
+    def list_methods():
+        async def execute() -> str:
+            """List every method available in the environment API."""
+            names = sorted(
+                p.name
+                for p in AGENT_TOOLS_DIR.iterdir()
+                if p.is_dir() and (p / "agent.md").exists()
+            )
+            return "\n".join(names)
+
+        return execute
+
+    @tool
+    def manual():
+        async def execute(method: str) -> str:
+            """Return the full documentation for one API method.
+
+            Args:
+                method: Name of the method, as returned by list_methods().
+            """
+            doc = AGENT_TOOLS_DIR / method / "agent.md"
+            if not doc.exists():
+                return (
+                    f"No such method: {method}. Use list_methods() to see valid names."
+                )
+            return doc.read_text()
+
+        return execute
+
+    @tool
+    def observe():
+        async def execute() -> str:
+            """Show current inventory, position, and nearby entities. Free."""
+            observation = gym_env.get_observation()
+            return _format_observation(observation)
+
+        return execute
+
+    @tool
+    def run_code():
+        async def execute(code: str) -> str:
+            """Execute a Python program in the environment.
+
+            Counts against the step budget. The namespace persists between
+            calls. Returns program output and the updated game state.
+
+            Args:
+                code: Python source using the environment API.
+            """
+            if trajectory.total_steps >= budget:
+                return "Step budget exhausted. No more run_code calls are allowed."
+
+            action = Action(agent_idx=0, code=code)
+            obs, reward, terminated, truncated, info = gym_env.step(action)
+            trajectory.total_steps += 1
+
+            score = obs.get("score") or 0.0
+            trajectory.current_score = score
+            trajectory.production_score = score
+
+            observation = gym_env.get_observation()
+            remaining = budget - trajectory.total_steps
+            return (
+                f"[step {trajectory.total_steps}/{budget}, "
+                f"production score {score:.1f}]\n"
+                f"{_format_observation(observation)}\n"
+                f"({remaining} run_code calls remaining)"
+            )
+
+        return execute
+
+    return [list_methods(), manual(), observe(), run_code()]
+
+
+def _trim_messages(messages, keep_last: int = 40):
+    """Keep the system prompt, the opening user message, and the recent tail."""
+    if len(messages) <= keep_last + 2:
+        return messages
+    return messages[:2] + messages[-keep_last:]
+
+
+@solver
+def factorio_tool_discovery_solver():
+    """Solver where the agent discovers the API through tools instead of the prompt."""
+
+    async def solve(state: AgentState, *args, **kwargs) -> AgentState:
+        run_idx = None
+        gym_env = None
+        pool = None
+
+        try:
+            metadata = getattr(state, "metadata", {}) or {}
+            env_id = metadata.get("env_id", "iron_ore_throughput")
+            budget = int(metadata.get("trajectory_length", 64))
+
+            pool = await get_simple_server_pool()
+            allocation = await pool.get_server_allocation()
+            run_idx = allocation.run_idx
+            logger.info(f"tool_discovery: allocated server factorio_{run_idx}")
+
+            gym_env = gym.make(env_id, disable_env_checker=True, run_idx=run_idx)
+            gym_env.reset()
+
+            env_info = get_environment_info(env_id) or {}
+            goal = env_info.get("description", f"complete the task {env_id}")
+
+            trajectory = store_as(TrajectoryData)
+            tools = _make_tools(gym_env, trajectory, budget)
+
+            messages = [
+                ChatMessageSystem(
+                    content=SYSTEM_PROMPT.format(goal=goal, budget=budget)
+                ),
+                ChatMessageUser(
+                    content="Begin. Discover the API, then work toward the goal."
+                ),
+            ]
+
+            # Free tool calls (manuals, observe) mean more generations than
+            # steps; cap generations so a model that never acts still halts.
+            max_generations = budget * 3
+            generations = 0
+
+            while trajectory.total_steps < budget and generations < max_generations:
+                generations += 1
+                output = await get_model().generate(
+                    input=_trim_messages(messages),
+                    tools=tools,
+                    config=GenerateConfig(max_tokens=4096),
+                )
+                messages.append(output.message)
+
+                if output.message.tool_calls:
+                    result = await execute_tools(messages, tools)
+                    messages.extend(result.messages)
+                else:
+                    messages.append(
+                        ChatMessageUser(
+                            content="Use your tools: read manuals, observe, or run_code."
+                        )
+                    )
+
+            trajectory.final_score = trajectory.current_score
+            trajectory.final_automated_score = trajectory.automated_production_score
+            logger.info(
+                f"tool_discovery: finished with score {trajectory.final_score:.1f} "
+                f"after {trajectory.total_steps} steps / {generations} generations"
+            )
+
+            state.messages = messages
+            state.output = output if generations else state.output
+            return state
+
+        finally:
+            if gym_env is not None:
+                try:
+                    gym_env.close()
+                except Exception:
+                    pass
+            if pool is not None and run_idx is not None:
+                await pool.release_run_idx(run_idx)
+                logger.info(f"tool_discovery: released server factorio_{run_idx}")
+
+    return solve

--- a/fle/eval/inspect/integration/solver_tool_discovery.py
+++ b/fle/eval/inspect/integration/solver_tool_discovery.py
@@ -1,14 +1,17 @@
 """Tool-discovery solver: the agent is not given the API manual up front.
 
 Every other solver injects the full SystemPromptGenerator manual into the
-system prompt and ablates observations/images. This solver inverts that:
-a minimal system prompt plus Inspect-native tools that let the agent look
-the rules up itself (the same content the MCP server exposes via ls/man),
-so the cost of acquiring the rules becomes part of the measured behavior.
+system prompt and streams the entire game state back after every step.
+This solver inverts both: a minimal system prompt, and a set of
+Inspect-native tools through which the agent pulls what it needs —
+documentation (list_methods/manual), state (entities/inventory/summary),
+its objective (task), and execution (run_code). run_code returns only the
+program's own STDOUT/STDERR; observing the world is a deliberate,
+separate act.
 
 Budget semantics: only `run_code` calls count against trajectory_length.
-Reading manuals and observing are free actions, so scores stay comparable
-with the controlled solver's step budget; the discovery cost shows up as
+Documentation and state queries are free, so scores stay comparable with
+the controlled solver's step budget; the discovery cost shows up as
 extra tokens and wall-clock, not lost game actions.
 """
 
@@ -31,11 +34,10 @@ from inspect_ai.util import store_as
 
 from fle.env.gym_env.action import Action
 from fle.env.gym_env.environment import FactorioGymEnv
-from fle.env.gym_env.observation import Observation
-from fle.env.gym_env.observation_formatter import TreeObservationFormatter
 from fle.env.gym_env.registry import get_environment_info
 from fle.eval.inspect.integration.simple_server_pool import get_simple_server_pool
 from fle.eval.inspect.integration.solver import TrajectoryData
+from fle.eval.tasks.task_definitions.lab_play.throughput_tasks import THROUGHPUT_TASKS
 
 logger = logging.getLogger(__name__)
 
@@ -45,29 +47,37 @@ AGENT_TOOLS_DIR = Path(
 
 SYSTEM_PROMPT = """You control a character in a Factorio world by writing Python programs.
 
-You have NOT been given the API documentation. Discover it with your tools:
+You have NOT been given the API documentation or the game state. Pull what
+you need through your tools:
+
+Documentation (free):
 - list_methods() lists every method in the environment API
 - manual(method) returns the full documentation for one method
-- observe() shows your inventory, position, and nearby entities (free)
-- run_code(code) executes a Python program in the environment and returns \
-the resulting game state (counts against your step budget)
 
-Goal: {goal}
+State (free):
+- task() shows your objective, current score, and remaining step budget
+- entities() lists entities on the map
+- inventory() shows what you are carrying
+- summary() gives a one-glance situational overview
 
-You have {budget} run_code calls. Reading manuals and observing are free.
-Read the manuals for methods before using them; API misuse wastes steps.
-Programs run in a persistent namespace: variables survive between run_code calls."""
+Action (budgeted):
+- run_code(code) executes a Python program in the environment and returns
+  its STDOUT/STDERR. You have {budget} run_code calls.
 
-
-def _format_observation(observation: Observation) -> str:
-    formatted = TreeObservationFormatter(
-        include_research=False, include_flows=False
-    ).format(observation)
-    return formatted.raw_str.replace("\\n", "\n")
+The Python namespace persists between run_code calls. Read the manual for a
+method before using it; API misuse wastes budget. Check state deliberately —
+run_code will not echo the world back at you."""
 
 
-def _make_tools(gym_env: FactorioGymEnv, trajectory: TrajectoryData, budget: int):
+def _make_tools(
+    gym_env: FactorioGymEnv, trajectory: TrajectoryData, budget: int, task_meta: dict
+):
     """Build per-sample tool closures over the live gym environment."""
+    ns = (
+        gym_env.unwrapped.instance.namespace
+        if hasattr(gym_env, "unwrapped")
+        else gym_env.instance.namespace
+    )
 
     @tool
     def list_methods():
@@ -100,11 +110,58 @@ def _make_tools(gym_env: FactorioGymEnv, trajectory: TrajectoryData, budget: int
         return execute
 
     @tool
-    def observe():
+    def task():
         async def execute() -> str:
-            """Show current inventory, position, and nearby entities. Free."""
-            observation = gym_env.get_observation()
-            return _format_observation(observation)
+            """Show the objective, target quota, current score, and remaining budget."""
+            return (
+                f"Objective: {task_meta['goal']}\n"
+                f"Target: {task_meta['quota']}\n"
+                f"Current production score: {trajectory.current_score:.1f}\n"
+                f"run_code calls used: {trajectory.total_steps}/{budget}"
+            )
+
+        return execute
+
+    @tool
+    def entities():
+        async def execute() -> str:
+            """List the entities currently on the map."""
+            found = ns.get_entities()
+            if not found:
+                return "No entities on the map yet."
+            return "\n".join(repr(e) for e in found)
+
+        return execute
+
+    @tool
+    def inventory():
+        async def execute() -> str:
+            """Show the contents of your inventory."""
+            inv = ns.inspect_inventory()
+            items = dict(inv.items()) if hasattr(inv, "items") else dict(inv)
+            if not items:
+                return "Inventory is empty."
+            return "\n".join(
+                f"{name}: {count}" for name, count in sorted(items.items())
+            )
+
+        return execute
+
+    @tool
+    def summary():
+        async def execute() -> str:
+            """One-glance overview: position, score, budget, entity and item counts."""
+            found = ns.get_entities()
+            inv = ns.inspect_inventory()
+            items = dict(inv.items()) if hasattr(inv, "items") else dict(inv)
+            pos = getattr(ns, "player_location", None)
+            return (
+                f"Position: {pos}\n"
+                f"Production score: {trajectory.current_score:.1f} (target {task_meta['quota']})\n"
+                f"run_code budget: {budget - trajectory.total_steps} of {budget} remaining\n"
+                f"Entities on map: {len(found)}\n"
+                f"Inventory: {sum(items.values())} items across {len(items)} types"
+            )
 
         return execute
 
@@ -114,7 +171,8 @@ def _make_tools(gym_env: FactorioGymEnv, trajectory: TrajectoryData, budget: int
             """Execute a Python program in the environment.
 
             Counts against the step budget. The namespace persists between
-            calls. Returns program output and the updated game state.
+            calls. Returns the program's STDOUT/STDERR only — use the state
+            tools to observe the world.
 
             Args:
                 code: Python source using the environment API.
@@ -131,21 +189,19 @@ def _make_tools(gym_env: FactorioGymEnv, trajectory: TrajectoryData, budget: int
             trajectory.production_score = score
 
             program_output = (info.get("result") if info else "") or "(no output)"
-
-            observation = gym_env.get_observation()
-            remaining = budget - trajectory.total_steps
-            return (
-                f"[step {trajectory.total_steps}/{budget}, "
-                f"production score {score:.1f}]\n\n"
-                f"Program output (STDOUT/STDERR):\n"
-                f"```\n{program_output}\n```\n\n"
-                f"Game state:\n{_format_observation(observation)}\n"
-                f"({remaining} run_code calls remaining)"
-            )
+            return f"{program_output}\n[step {trajectory.total_steps}/{budget} used]"
 
         return execute
 
-    return [list_methods(), manual(), observe(), run_code()]
+    return [
+        list_methods(),
+        manual(),
+        task(),
+        entities(),
+        inventory(),
+        summary(),
+        run_code(),
+    ]
 
 
 def _trim_messages(messages, keep_last: int = 40):
@@ -166,7 +222,7 @@ def _trim_messages(messages, keep_last: int = 40):
 
 @solver
 def factorio_tool_discovery_solver():
-    """Solver where the agent discovers the API through tools instead of the prompt."""
+    """Solver where the agent discovers the API and state through tools."""
 
     async def solve(state: AgentState, *args, **kwargs) -> AgentState:
         run_idx = None
@@ -187,24 +243,28 @@ def factorio_tool_discovery_solver():
             gym_env.reset()
 
             env_info = get_environment_info(env_id) or {}
-            goal = env_info.get("description", f"complete the task {env_id}")
+            task_config = THROUGHPUT_TASKS.get(env_id)
+            task_meta = {
+                "goal": env_info.get("description")
+                or (task_config.goal_description if task_config else env_id),
+                "quota": task_config.quota if task_config else "n/a",
+            }
 
             trajectory = store_as(TrajectoryData)
-            tools = _make_tools(gym_env, trajectory, budget)
+            tools = _make_tools(gym_env, trajectory, budget, task_meta)
 
             messages = [
-                ChatMessageSystem(
-                    content=SYSTEM_PROMPT.format(goal=goal, budget=budget)
-                ),
+                ChatMessageSystem(content=SYSTEM_PROMPT.format(budget=budget)),
                 ChatMessageUser(
-                    content="Begin. Discover the API, then work toward the goal."
+                    content="Begin. Check task(), discover the API, then work toward the goal."
                 ),
             ]
 
-            # Free tool calls (manuals, observe) mean more generations than
-            # steps; cap generations so a model that never acts still halts.
+            # Free tool calls mean more generations than steps; cap
+            # generations so a model that never acts still halts.
             max_generations = budget * 3
             generations = 0
+            output = None
 
             while trajectory.total_steps < budget and generations < max_generations:
                 generations += 1
@@ -223,7 +283,7 @@ def factorio_tool_discovery_solver():
                 else:
                     messages.append(
                         ChatMessageUser(
-                            content="Use your tools: read manuals, observe, or run_code."
+                            content="Use your tools: read manuals, check state, or run_code."
                         )
                     )
 
@@ -235,7 +295,8 @@ def factorio_tool_discovery_solver():
             )
 
             state.messages = messages
-            state.output = output if generations else state.output
+            if output is not None:
+                state.output = output
             return state
 
         finally:

--- a/fle/eval/inspect/integration/solver_tool_discovery.py
+++ b/fle/eval/inspect/integration/solver_tool_discovery.py
@@ -204,9 +204,7 @@ def factorio_tool_discovery_solver():
                     tools=tools,
                     # timeout: a hung provider request otherwise stalls the
                     # epoch indefinitely (observed with OpenRouter).
-                    config=GenerateConfig(
-                        max_tokens=4096, timeout=300, max_retries=3
-                    ),
+                    config=GenerateConfig(max_tokens=4096, timeout=300, max_retries=3),
                 )
                 messages.append(output.message)
 

--- a/fle/eval/inspect/integration/solver_tool_discovery.py
+++ b/fle/eval/inspect/integration/solver_tool_discovery.py
@@ -15,6 +15,7 @@ the controlled solver's step budget; the discovery cost shows up as
 extra tokens and wall-clock, not lost game actions.
 """
 
+import asyncio
 import importlib.resources
 import logging
 from pathlib import Path
@@ -73,6 +74,11 @@ def _make_tools(
     gym_env: FactorioGymEnv, trajectory: TrajectoryData, budget: int, task_meta: dict
 ):
     """Build per-sample tool closures over the live gym environment."""
+    # The RCON client is not safe for concurrent calls ("The client is
+    # already busy with another call"), and Inspect may execute multiple
+    # tool calls from one assistant message in parallel. Serialize every
+    # env-touching tool on one lock.
+    env_lock = asyncio.Lock()
     ns = (
         gym_env.unwrapped.instance.namespace
         if hasattr(gym_env, "unwrapped")
@@ -126,7 +132,8 @@ def _make_tools(
     def entities():
         async def execute() -> str:
             """List the entities currently on the map."""
-            found = ns.get_entities()
+            async with env_lock:
+                found = ns.get_entities()
             if not found:
                 return "No entities on the map yet."
             return "\n".join(repr(e) for e in found)
@@ -137,7 +144,8 @@ def _make_tools(
     def inventory():
         async def execute() -> str:
             """Show the contents of your inventory."""
-            inv = ns.inspect_inventory()
+            async with env_lock:
+                inv = ns.inspect_inventory()
             items = dict(inv.items()) if hasattr(inv, "items") else dict(inv)
             if not items:
                 return "Inventory is empty."
@@ -151,8 +159,9 @@ def _make_tools(
     def summary():
         async def execute() -> str:
             """One-glance overview: position, score, budget, entity and item counts."""
-            found = ns.get_entities()
-            inv = ns.inspect_inventory()
+            async with env_lock:
+                found = ns.get_entities()
+                inv = ns.inspect_inventory()
             items = dict(inv.items()) if hasattr(inv, "items") else dict(inv)
             pos = getattr(ns, "player_location", None)
             return (
@@ -181,7 +190,8 @@ def _make_tools(
                 return "Step budget exhausted. No more run_code calls are allowed."
 
             action = Action(agent_idx=0, code=code)
-            obs, reward, terminated, truncated, info = gym_env.step(action)
+            async with env_lock:
+                obs, reward, terminated, truncated, info = gym_env.step(action)
             trajectory.total_steps += 1
 
             score = obs.get("score") or 0.0

--- a/fle/eval/inspect/integration/solver_tool_discovery.py
+++ b/fle/eval/inspect/integration/solver_tool_discovery.py
@@ -149,10 +149,19 @@ def _make_tools(gym_env: FactorioGymEnv, trajectory: TrajectoryData, budget: int
 
 
 def _trim_messages(messages, keep_last: int = 40):
-    """Keep the system prompt, the opening user message, and the recent tail."""
+    """Keep the system prompt, the opening user message, and the recent tail.
+
+    The tail must not begin with tool-result messages: their parent
+    assistant tool_call message would be trimmed away, and OpenAI rejects
+    histories containing a function result with no matching call ("No tool
+    call found for function call output with call_id ...").
+    """
     if len(messages) <= keep_last + 2:
         return messages
-    return messages[:2] + messages[-keep_last:]
+    tail = messages[-keep_last:]
+    while tail and getattr(tail[0], "role", None) == "tool":
+        tail = tail[1:]
+    return messages[:2] + tail
 
 
 @solver

--- a/fle/eval/inspect/integration/solver_tool_discovery.py
+++ b/fle/eval/inspect/integration/solver_tool_discovery.py
@@ -130,12 +130,16 @@ def _make_tools(gym_env: FactorioGymEnv, trajectory: TrajectoryData, budget: int
             trajectory.current_score = score
             trajectory.production_score = score
 
+            program_output = (info.get("result") if info else "") or "(no output)"
+
             observation = gym_env.get_observation()
             remaining = budget - trajectory.total_steps
             return (
                 f"[step {trajectory.total_steps}/{budget}, "
-                f"production score {score:.1f}]\n"
-                f"{_format_observation(observation)}\n"
+                f"production score {score:.1f}]\n\n"
+                f"Program output (STDOUT/STDERR):\n"
+                f"```\n{program_output}\n```\n\n"
+                f"Game state:\n{_format_observation(observation)}\n"
                 f"({remaining} run_code calls remaining)"
             )
 

--- a/fle/eval/inspect/integration/solver_tool_discovery.py
+++ b/fle/eval/inspect/integration/solver_tool_discovery.py
@@ -202,7 +202,11 @@ def factorio_tool_discovery_solver():
                 output = await get_model().generate(
                     input=_trim_messages(messages),
                     tools=tools,
-                    config=GenerateConfig(max_tokens=4096),
+                    # timeout: a hung provider request otherwise stalls the
+                    # epoch indefinitely (observed with OpenRouter).
+                    config=GenerateConfig(
+                        max_tokens=4096, timeout=300, max_retries=3
+                    ),
                 )
                 messages.append(output.message)
 

--- a/fle/eval/inspect/integration/solver_utils.py
+++ b/fle/eval/inspect/integration/solver_utils.py
@@ -532,7 +532,14 @@ def trim_messages(
     Returns:
         Trimmed message list
     """
-    if len(messages) <= max_messages:
+    # Hysteresis: with a narrow gap between max_messages and trim_to the
+    # window re-trims every step or two, shifting the prompt prefix and
+    # defeating provider prompt caching (only the system head ever
+    # cache-hits). Widen the trigger so the prefix stays stable for many
+    # steps between trims; the kept context after a trim is unchanged
+    # (trim_to), so each variant's context ablation is preserved.
+    trigger = max(max_messages, 2 * trim_to + 1)
+    if len(messages) <= trigger:
         if strip_images:
             return strip_images_from_messages(messages)
         return messages

--- a/fle/run.py
+++ b/fle/run.py
@@ -53,6 +53,32 @@ def fle_eval(args):
         sys.exit(1)
 
 
+def _resolve_openrouter_provider(model: str):
+    """Resolve the current top tool-capable provider for an OpenRouter model.
+
+    Pinning consecutive requests to one provider keeps its prompt cache
+    warm; unpinned routing can bounce between providers (some without
+    caching at all). Best-effort: returns None on any failure.
+    """
+    import json
+    import urllib.request
+
+    slug = model.split("openrouter/", 1)[1]
+    try:
+        with urllib.request.urlopen(
+            f"https://openrouter.ai/api/v1/models/{slug}/endpoints", timeout=10
+        ) as r:
+            endpoints = json.load(r).get("data", {}).get("endpoints", [])
+        with_tools = [
+            e for e in endpoints if "tools" in (e.get("supported_parameters") or [])
+        ]
+        chosen = (with_tools or endpoints)[0] if endpoints else None
+        return chosen.get("provider_name") if chosen else None
+    except Exception as e:
+        print(f"OpenRouter provider pinning skipped: {e}")
+        return None
+
+
 def fle_inspect_eval(args):
     """New command: fle inspect-eval using Inspect framework"""
     _eval_integration_dir = Path(__file__).parent / "eval" / "inspect" / "integration"
@@ -233,6 +259,19 @@ def fle_inspect_eval(args):
 
         if "openrouter" in args.model:
             cmd.extend(["-M", "transforms=['middle-out']"])
+            # Pin routing to one provider so its prompt cache stays warm.
+            if not getattr(args, "no_pin_provider", False):
+                pin = getattr(
+                    args, "pin_provider", None
+                ) or _resolve_openrouter_provider(args.model)
+                if pin:
+                    cmd.extend(
+                        [
+                            "-M",
+                            f"provider={{'order': ['{pin}'], 'allow_fallbacks': False}}",
+                        ]
+                    )
+                    print(f"Pinned OpenRouter provider: {pin}")
         # Set environment variables for dynamic task configuration
         if args.env_id:
             os.environ["FLE_ENV_ID"] = args.env_id
@@ -643,6 +682,16 @@ Examples:
     )
     parser_inspect.add_argument(
         "--env-id", help="Specific environment/task to evaluate (default: all tasks)"
+    )
+    parser_inspect.add_argument(
+        "--pin-provider",
+        help="Pin OpenRouter routing to this provider (default: auto-resolve "
+        "the top tool-capable provider to keep its prompt cache warm)",
+    )
+    parser_inspect.add_argument(
+        "--no-pin-provider",
+        action="store_true",
+        help="Disable automatic OpenRouter provider pinning",
     )
     parser_inspect.add_argument(
         "--no-fail-on-error",

--- a/fle/run.py
+++ b/fle/run.py
@@ -226,6 +226,11 @@ def fle_inspect_eval(args):
             # Unbounded tasks use mean reducer by default
             cmd.extend(["--epochs-reducer", "mean"])
 
+        # Fail the eval loudly if any sample errors (e.g. no Factorio server
+        # for a rollout) instead of reporting scores over partial rollouts.
+        if not (hasattr(args, "no_fail_on_error") and args.no_fail_on_error):
+            cmd.extend(["--fail-on-error"])
+
         if "openrouter" in args.model:
             cmd.extend(["-M", "transforms=['middle-out']"])
         # Set environment variables for dynamic task configuration
@@ -638,6 +643,12 @@ Examples:
     )
     parser_inspect.add_argument(
         "--env-id", help="Specific environment/task to evaluate (default: all tasks)"
+    )
+    parser_inspect.add_argument(
+        "--no-fail-on-error",
+        action="store_true",
+        help="Allow the eval to complete even if some samples error "
+        "(default: any errored sample fails the eval)",
     )
     parser_inspect.add_argument(
         "--init-retries",

--- a/fle/run.py
+++ b/fle/run.py
@@ -665,6 +665,7 @@ Examples:
             "balanced",
             "reasoning_only",
             "pruned_gamestate",
+            "tool_discovery",
         ],
         help="Solver variant to use (default depends on task type)",
     )


### PR DESCRIPTION
## What
A new Inspect solver variant, `tool_discovery`, that inverts the standard prompt design: instead of injecting the full SystemPromptGenerator manual into the system prompt, the agent gets a minimal prompt plus Inspect-native tools to discover the rules itself:

- `list_methods()` — enumerate the environment API
- `manual(method)` — full documentation for one method (same per-tool agent.md files the MCP server serves)
- `observe()` — current inventory/position/entities (free)
- `run_code(code)` — execute Python in the environment (counts against the step budget)

Only `run_code` consumes trajectory_length; manuals and observation are free, so scores stay comparable with `controlled` — the cost of acquiring the rules shows up as tokens/latency, not lost game actions. A 3×-budget generation cap halts models that read forever without acting.

Server allocation (SimpleServerPool), TrajectoryData scoring, and pass@k wiring are unchanged. Registered in SOLVER_MAP, the `--solver` CLI choices, and gains an `open_play_tool_discovery` task via the existing variant machinery. The solver-choices sync test passes.

## Why
None of the 12 existing solver variants ablate the manual — they ablate observations/images/HUD. The MCP server implements rules-discovery interactively but has no eval harness; PR #158 tried a RAG variant years ago (unmergeable). This makes "can the agent learn the environment?" a measurable question.

## Smoke test (live server, OpenRouter, gpt-4o-mini, 8-step budget)
iron_ore_throughput: score 21.0/16 → scorer 1.0. Trajectory shows the intended behavior: list_methods ×1, manual ×7, observe ×1, run_code ×8 (exact budget), clean server release. 2m06s, 58k tokens.

## Known gaps (follow-ups)
- Per-step score/timing arrays in TrajectoryData are not populated (only totals/finals)
- automated_production_score is not computed (needs the flows-delta logic from the controlled solver); the smoke run hand-mined its ore
- No vision/render tool yet — text-only, closest comparison is text_only/controlled