### PR TITLE
fix(inspect): scope middle-out transform to OpenRouter

### DIFF
--- a/fle/eval/inspect/sandbox/sandbox_solver.py
+++ b/fle/eval/inspect/sandbox/sandbox_solver.py
@@ -241,7 +241,6 @@ Analyze the current state and write a Python program using the FLE API to progre
                     # Generate LLM response (host-side)
                     generation_config = {
                         "max_tokens": 4096,
-                        "transforms": ["middle-out"],
                         "reasoning_effort": "minimal",
                     }
                     state.output = await get_model().generate(

--- a/fle/eval/inspect/sandbox/sandbox_solver.py
+++ b/fle/eval/inspect/sandbox/sandbox_solver.py
@@ -243,7 +243,14 @@ Analyze the current state and write a Python program using the FLE API to progre
                         "max_tokens": 4096,
                         "reasoning_effort": "minimal",
                     }
-                    state.output = await get_model().generate(
+                    _model = get_model()
+                    model_name_str = (
+                        getattr(_model, "name", "") if hasattr(_model, "name") else ""
+                    )
+                    if model_name_str and "openrouter" in model_name_str:
+                        generation_config["transforms"] = ["middle-out"]
+
+                    state.output = await _model.generate(
                         input=state.messages,
                         config=generation_config,
                     )


### PR DESCRIPTION
Summary

- Remove the unconditional middle-out transform from the controlled sandbox solver.
- Resolve the configured model once per generation.
- Apply transforms=["middle-out"] only when the model is routed through OpenRouter, matching the existing unbounded-solver behavior (see lines 591-602).

Why

middle-out is an OpenRouter-specific input-context transform. Sending it to direct or OpenAI-compatible non-OpenRouter model providers can cause unsupported-parameter failures.

Testing

- uv run python -m compileall -q fle/eval/inspect/sandbox/sandbox_solver.py
- git diff --check